### PR TITLE
Improve mobile event creation form

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -196,6 +196,8 @@ a { color: var(--primary); text-decoration: none; }
 label > div { color: var(--muted); font-size: 12px; margin-bottom: 6px; }
 input[type="text"],
 input[type="datetime-local"],
+input[type="date"],
+input[type="time"],
 select,
 textarea {
   width: 100%;
@@ -241,3 +243,6 @@ input:focus, select:focus, textarea:focus {
 /* Center and scale modal */
 .modal-root { position: fixed; inset: 0; display: grid; place-items: center; background: rgba(0,0,0,.55); z-index: 50; }
 .modal-card { width: 640px; max-width: 92vw; }
+@media (max-width: 640px) {
+  .modal-card { width: 100vw; max-width: 100vw; height: 100vh; border-radius: 0; }
+}


### PR DESCRIPTION
## Summary
- Detect small screens and adjust event creation form for mobile users
- Split start and end inputs into separate date and time fields on mobile
- Style modal and inputs for better mobile usability

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8dbc6f6dc8320b71382cb2807862c