### PR TITLE
Use white text on yellow events

### DIFF
--- a/my-calendar-main/src/styles/calendar.css
+++ b/my-calendar-main/src/styles/calendar.css
@@ -63,7 +63,7 @@
 .fc .fc-event.evt-temp-fence {
   --fc-event-bg-color: var(--evt-temp-fence);
   --fc-event-border-color: var(--evt-temp-fence);
-  --fc-event-text-color: #111; /* better on yellow */
+  --fc-event-text-color: #fff; /* white text on yellow */
 }
 .fc .fc-event.evt-handrail {
   --fc-event-bg-color: var(--evt-handrail);
@@ -173,7 +173,7 @@
   border-color: var(--evt-temp-fence) !important;
   --fc-event-bg-color: var(--evt-temp-fence);
   --fc-event-border-color: var(--evt-temp-fence);
-  color: #111 !important; /* better on yellow */
+  color: #fff !important; /* white text on yellow */
 }
 .fc .fc-event.evt-handrail,
 .fc .fc-h-event.evt-handrail,

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -71,7 +71,7 @@
 .fc .fc-event.evt-temp-fence {
   --fc-event-bg-color: var(--evt-temp-fence);
   --fc-event-border-color: var(--evt-temp-fence);
-  --fc-event-text-color: #111; /* better on yellow */
+  --fc-event-text-color: #fff; /* white text on yellow */
 }
 .fc .fc-event.evt-handrail {
   --fc-event-bg-color: var(--evt-handrail);
@@ -191,7 +191,7 @@
   border-color: var(--evt-temp-fence) !important;
   --fc-event-bg-color: var(--evt-temp-fence);
   --fc-event-border-color: var(--evt-temp-fence);
-  color: #111 !important; /* better on yellow */
+  color: #fff !important; /* white text on yellow */
 }
 .fc .fc-event.evt-handrail,
 .fc .fc-h-event.evt-handrail,


### PR DESCRIPTION
## Summary
- display white text for yellow temp-fence events
- update duplicate calendar stylesheet to match

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bedf4e47588320b1771a3c82399197