### PR TITLE
Revamp Add Event modal with grouped layout and controls

### DIFF
--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -99,6 +99,12 @@
 .modal-actions { display: flex; gap: 0.5rem; justify-content: flex-end; }
 .btn { padding: 0.45rem 0.8rem; border-radius: 10px; border: 1px solid var(--border); color: var(--text); }
 .btn.primary { background: linear-gradient(180deg, var(--primary), #0063e1); color: var(--primary-contrast); border-color: #0a4aa6; }
+.form-section { font-size: 0.9rem; font-weight: 500; color: var(--text); margin-top: 0.5rem; }
+.label .ico { width: 1rem; height: 1rem; margin-right: 0.25rem; }
+.type-chip { width: 12px; height: 12px; border-radius: 999px; display: inline-block; }
+.shift-toggle { width: 100%; border: 1px solid var(--border); border-radius: 10px; padding: 0.55rem 0.65rem; background: var(--card-2); color: var(--text); }
+.shift-toggle.night { background: var(--elev-2); }
+.form-grid input, .form-grid select, .form-grid textarea, .shift-toggle { min-height: 44px; }
 
 /* ===== Day Weather (tiny, next to date) ===== */
 .fc .day-weather { margin-left: 2px; margin-right: 0; font-size: 0.72rem; color: var(--text-dim); text-decoration: none; display: inline-flex; gap: 4px; align-items: center; opacity: .95; }


### PR DESCRIPTION
## Summary
- Group add-event fields into Event Info, Work Details, Tickets, and Subtasks sections
- Replace day/night radios with a large toggle and show type color chips
- Add Google Places autocomplete and numeric keypad hints for location and ticket inputs
- Fix compile error by moving keyboard shortcut handler after saveDraft definition

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf3a2848348320b15e53cf3e230c89