### PR TITLE
Add vendor and payroll options to event creation form

### DIFF
--- a/src/types/chrono-node.d.ts
+++ b/src/types/chrono-node.d.ts
@@ -1,0 +1,1 @@
+declare module 'chrono-node';


### PR DESCRIPTION
## Summary
- allow choosing Jorge, Tony, or Chris as event vendor with color-coded selection
- add payroll yes/no field when adding events
- parse and store vendor and payroll metadata with events
## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf986add48832093cb22c49b30ea71