### PR TITLE
Fix missing parenthesis in CalendarWithData

### DIFF
--- a/src/components/CalendarWithData.tsx
+++ b/src/components/CalendarWithData.tsx
@@ -585,7 +585,7 @@ export default function CalendarWithData({ calendarId, initialYear, initialMonth
         },
         className: typeToClass(u.type),
         display: 'block',
-      } : ev));
+        } : ev)));
     } else {
       const r = await fetch(`/api/calendars/${calendarId}/events`, { method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ title: draft.title, description: composeDescription(draft.description ?? '', draft.invoice ?? '', draft.payment ?? '', draft.vendor ?? '', draft.payroll ?? false), start: fromLocalInput(draft.start), end: fromLocalInput(draft.end ?? draft.start), allDay: !!draft.allDay, location: draft.location ?? '', type: draft.type ?? null, payment: draft.payment ?? null, vendor: draft.vendor ?? null, payroll: draft.payroll ?? null, shift: draft.shift ?? null, checklist: draft.checklist ?? null }) });


### PR DESCRIPTION
## Summary
- add missing closing parenthesis in CalendarWithData event update

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c07e19dd788320897351597163be55