### PR TITLE
Add employee selection and management features

### DIFF
--- a/src/app/employees/page.tsx
+++ b/src/app/employees/page.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+import {
+  getEmployees,
+  addEmployee,
+  updateEmployee,
+  deleteEmployee,
+  resetEmployees,
+  type Employee,
+  type Team,
+} from "../../employees";
+
+export default function EmployeesPage() {
+  const [employees, setEmployees] = useState<Employee[]>(getEmployees());
+  const [search, setSearch] = useState("");
+
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [team, setTeam] = useState<Team>("South");
+
+  const [editing, setEditing] = useState<string | null>(null);
+  const [editFirst, setEditFirst] = useState("");
+  const [editLast, setEditLast] = useState("");
+  const [editTeam, setEditTeam] = useState<Team>("South");
+
+  const refresh = () => setEmployees(getEmployees());
+
+  const filtered = employees.filter((e) =>
+    `${e.firstName} ${e.lastName}`
+      .toLowerCase()
+      .includes(search.toLowerCase())
+  );
+
+  function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (!firstName.trim() || !lastName.trim()) return;
+    addEmployee({ firstName: firstName.trim(), lastName: lastName.trim(), team });
+    setFirstName("");
+    setLastName("");
+    setTeam("South");
+    refresh();
+  }
+
+  function startEdit(emp: Employee) {
+    setEditing(emp.id);
+    setEditFirst(emp.firstName);
+    setEditLast(emp.lastName);
+    setEditTeam(emp.team);
+  }
+
+  function saveEdit(id: string) {
+    updateEmployee(id, { firstName: editFirst, lastName: editLast, team: editTeam });
+    setEditing(null);
+    refresh();
+  }
+
+  function cancelEdit() {
+    setEditing(null);
+  }
+
+  function remove(id: string) {
+    deleteEmployee(id);
+    refresh();
+  }
+
+  function reset() {
+    resetEmployees();
+    refresh();
+  }
+
+  return (
+    <main className="p-4 space-y-6">
+      <div className="flex justify-between items-center">
+        <input
+          type="text"
+          placeholder="Search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="border px-2 py-1 rounded"
+        />
+        <button className="btn ghost" onClick={reset}>Reset to seed</button>
+      </div>
+      <form onSubmit={handleAdd} className="flex flex-wrap gap-2 items-end">
+        <div>
+          <label className="block text-sm mb-1">First name</label>
+          <input
+            className="border px-2 py-1 rounded"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Last name</label>
+          <input
+            className="border px-2 py-1 rounded"
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Team</label>
+          <select
+            className="border px-2 py-1 rounded"
+            value={team}
+            onChange={(e) => setTeam(e.target.value as Team)}
+          >
+            <option value="South">South</option>
+            <option value="Central">Central</option>
+          </select>
+        </div>
+        <button type="submit" className="btn primary">Add</button>
+      </form>
+      <table className="w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="border px-2 py-1 text-left">First</th>
+            <th className="border px-2 py-1 text-left">Last</th>
+            <th className="border px-2 py-1 text-left">Team</th>
+            <th className="border px-2 py-1">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((e) => (
+            <tr key={e.id} className="border-t">
+              {editing === e.id ? (
+                <>
+                  <td className="border px-2 py-1">
+                    <input
+                      className="border px-1 py-0.5 rounded w-full"
+                      value={editFirst}
+                      onChange={(ev) => setEditFirst(ev.target.value)}
+                    />
+                  </td>
+                  <td className="border px-2 py-1">
+                    <input
+                      className="border px-1 py-0.5 rounded w-full"
+                      value={editLast}
+                      onChange={(ev) => setEditLast(ev.target.value)}
+                    />
+                  </td>
+                  <td className="border px-2 py-1">
+                    <select
+                      className="border px-1 py-0.5 rounded w-full"
+                      value={editTeam}
+                      onChange={(ev) => setEditTeam(ev.target.value as Team)}
+                    >
+                      <option value="South">South</option>
+                      <option value="Central">Central</option>
+                    </select>
+                  </td>
+                  <td className="border px-2 py-1 space-x-2 text-center">
+                    <button className="btn" onClick={() => saveEdit(e.id)}>Save</button>
+                    <button className="btn ghost" onClick={cancelEdit}>Cancel</button>
+                  </td>
+                </>
+              ) : (
+                <>
+                  <td className="border px-2 py-1">{e.firstName}</td>
+                  <td className="border px-2 py-1">{e.lastName}</td>
+                  <td className="border px-2 py-1">{e.team}</td>
+                  <td className="border px-2 py-1 space-x-2 text-center">
+                    <button className="btn" onClick={() => startEdit(e)}>Edit</button>
+                    <button className="btn danger" onClick={() => remove(e.id)}>Delete</button>
+                  </td>
+                </>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}
+

--- a/src/app/example-employee-picker/page.tsx
+++ b/src/app/example-employee-picker/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import EmployeeMultiSelect from "../../components/EmployeeMultiSelect";
+import { getEmployees } from "../../employees";
+
+const busyMap: Record<string, string[]> = {
+  "2024-05-01": ["edilberto-acuna"],
+  "2024-05-02": ["christopher-jones", "troy-sturgil"],
+};
+
+export default function ExampleEmployeePicker() {
+  const [date, setDate] = useState("");
+  const [policy, setPolicy] = useState<"warn" | "disable">("warn");
+  const [group, setGroup] = useState(false);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const employees = getEmployees();
+  const assigned = busyMap[date] || [];
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    alert(`Saved ${selected.length} employees`);
+  }
+
+  return (
+    <main className="p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block text-sm mb-1">Date</label>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="border px-2 py-1 rounded w-full"
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Conflict policy</label>
+          <select
+            value={policy}
+            onChange={(e) => setPolicy(e.target.value as any)}
+            className="border px-2 py-1 rounded w-full"
+          >
+            <option value="warn">warn</option>
+            <option value="disable">disable</option>
+          </select>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            id="group"
+            type="checkbox"
+            checked={group}
+            onChange={(e) => setGroup(e.target.checked)}
+          />
+          <label htmlFor="group">Group by team</label>
+        </div>
+        <EmployeeMultiSelect
+          employees={employees}
+          value={selected}
+          onChange={setSelected}
+          assignedEmployeeIds={assigned}
+          conflictPolicy={policy}
+          groupByTeam={group}
+          label="Employees"
+        />
+        <div>
+          <h2 className="text-sm font-semibold">Selected</h2>
+          <ul className="list-disc pl-4">
+            {selected.map((id) => {
+              const emp = employees.find((e) => e.id === id);
+              if (!emp) return null;
+              return (
+                <li key={id}>{emp.firstName} {emp.lastName}</li>
+              );
+            })}
+          </ul>
+        </div>
+        <button type="submit" className="btn primary">Save</button>
+      </form>
+    </main>
+  );
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import 'leaflet/dist/leaflet.css';
+import Header from "../components/Header";
 
 export const metadata: Metadata = {
   title: "GFC Calendar",
@@ -10,7 +11,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <Header />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/components/EmployeeMultiSelect.tsx
+++ b/src/components/EmployeeMultiSelect.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import type { Employee } from "../employees";
+
+interface Props {
+  employees: Employee[];
+  value: string[];
+  onChange: (next: string[]) => void;
+  assignedEmployeeIds?: string[];
+  conflictPolicy?: "disable" | "warn";
+  groupByTeam?: boolean;
+  placeholder?: string;
+  label?: string;
+}
+
+export default function EmployeeMultiSelect({
+  employees,
+  value,
+  onChange,
+  assignedEmployeeIds = [],
+  conflictPolicy = "warn",
+  groupByTeam = false,
+  placeholder = "Select employees",
+  label,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [active, setActive] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const filtered = employees.filter((e) =>
+    `${e.firstName} ${e.lastName}`
+      .toLowerCase()
+      .includes(search.toLowerCase())
+  );
+
+  const ordered = groupByTeam
+    ? filtered.sort((a, b) => a.team.localeCompare(b.team))
+    : filtered;
+
+  const flat = ordered;
+
+  const toggle = (id: string, disabled?: boolean) => {
+    if (disabled) return;
+    if (value.includes(id)) onChange(value.filter((v) => v !== id));
+    else onChange([...value, id]);
+  };
+
+  useEffect(() => {
+    if (open) setActive(0);
+  }, [open, search]);
+
+  useEffect(() => {
+    function handle(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) document.addEventListener("mousedown", handle);
+    return () => document.removeEventListener("mousedown", handle);
+  }, [open]);
+
+  useEffect(() => {
+    function handle(e: KeyboardEvent) {
+      if (!open || !flat.length) return;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActive((i) => (i + 1) % flat.length);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActive((i) => (i - 1 + flat.length) % flat.length);
+      } else if (e.key === " ") {
+        e.preventDefault();
+        const emp = flat[active];
+        if (emp) {
+          const busy = assignedEmployeeIds.includes(emp.id);
+          const disabled = busy && conflictPolicy === "disable";
+          toggle(emp.id, disabled);
+        }
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const emp = flat[active];
+        if (emp) {
+          const busy = assignedEmployeeIds.includes(emp.id);
+          const disabled = busy && conflictPolicy === "disable";
+          toggle(emp.id, disabled);
+        }
+        setOpen(false);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+      }
+    }
+    document.addEventListener("keydown", handle);
+    return () => document.removeEventListener("keydown", handle);
+  }, [open, active, flat, assignedEmployeeIds, conflictPolicy, value]);
+
+  const renderRow = (e: Employee, idx: number) => {
+    const busy = assignedEmployeeIds.includes(e.id);
+    const disabled = busy && conflictPolicy === "disable";
+    const selected = value.includes(e.id);
+    const highlight = idx === active;
+    return (
+      <li
+        key={e.id}
+        role="option"
+        aria-selected={selected}
+        onMouseEnter={() => setActive(idx)}
+        onClick={() => toggle(e.id, disabled)}
+        className={`px-2 py-1 flex items-center justify-between cursor-pointer ${highlight ? "bg-gray-100" : ""} ${disabled ? "opacity-50" : ""}`}
+      >
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={selected}
+            readOnly
+            disabled={disabled}
+            className="mr-2"
+          />
+          <span>{e.firstName} {e.lastName}</span>
+        </div>
+        {busy && (
+          <span className="text-xs text-red-600">
+            {conflictPolicy === "warn" ? "Busy (warn)" : "Busy"}
+          </span>
+        )}
+      </li>
+    );
+  };
+
+  const sections: { title: string; items: Employee[] }[] = [];
+  if (groupByTeam) {
+    const south = ordered.filter((e) => e.team === "South");
+    const central = ordered.filter((e) => e.team === "Central");
+    if (south.length) sections.push({ title: "South FL Team", items: south });
+    if (central.length) sections.push({ title: "Central FL Team", items: central });
+  }
+
+  const listContent = groupByTeam ? (
+    sections.map((s) => (
+      <div key={s.title}>
+        <div className="px-2 py-1 text-xs text-gray-500">{s.title}</div>
+        <ul>{s.items.map((e) => renderRow(e, flat.indexOf(e)))}</ul>
+      </div>
+    ))
+  ) : (
+    <ul>{flat.map((e, idx) => renderRow(e, idx))}</ul>
+  );
+
+  const labelText = label && <label className="block text-sm mb-1">{label}</label>;
+  const buttonText = value.length
+    ? employees
+        .filter((e) => value.includes(e.id))
+        .map((e) => `${e.firstName} ${e.lastName}`)
+        .join(", ")
+    : placeholder;
+
+  return (
+    <div className="relative" ref={containerRef}>
+      {labelText}
+      <button
+        type="button"
+        className="w-full border px-3 py-2 text-left rounded"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {buttonText}
+      </button>
+      {open && (
+        <div
+          className="absolute z-10 mt-1 w-full border bg-white rounded shadow"
+          role="listbox"
+          aria-multiselectable="true"
+        >
+          <div className="p-2 border-b">
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search"
+              className="w-full border px-2 py-1 rounded"
+            />
+            <button
+              type="button"
+              className="mt-2 text-sm text-blue-600"
+              onClick={() => onChange([])}
+            >
+              Clear all
+            </button>
+          </div>
+          <div className="max-h-64 overflow-y-auto">{listContent}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import Link from "next/link";
+
+export default function Header() {
+  return (
+    <header className="p-4 bg-gray-100">
+      <nav className="flex gap-4">
+        <Link href="/weather" className="btn">Weather</Link>
+        <Link href="/employees" className="btn">Employees</Link>
+      </nav>
+    </header>
+  );
+}
+

--- a/src/employees.ts
+++ b/src/employees.ts
@@ -1,0 +1,111 @@
+export type Team = "South" | "Central";
+export interface Employee {
+  id: string;
+  firstName: string;
+  lastName: string;
+  team: Team;
+}
+
+const LS_KEY = 'employees';
+
+function toId(first: string, last: string): string {
+  const kebab = (s: string) =>
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, '')
+      .trim()
+      .replace(/\s+/g, '-');
+  return `${kebab(first)}-${kebab(last)}`;
+}
+
+const seedData: Omit<Employee, 'id'>[] = [
+  { firstName: 'Adrian', lastName: 'Ramos', team: 'South' },
+  { firstName: 'Carlos', lastName: 'Manuel Diaz', team: 'South' },
+  { firstName: 'Christopher', lastName: 'Jones', team: 'Central' },
+  { firstName: 'Daniel', lastName: 'Buell Burnette', team: 'Central' },
+  { firstName: 'Edilberto', lastName: 'Acuna', team: 'South' },
+  { firstName: 'Esteban', lastName: 'Sanchez', team: 'South' },
+  { firstName: 'Fabian', lastName: 'Marquez', team: 'South' },
+  { firstName: 'Gerardo', lastName: 'Oliva', team: 'South' },
+  { firstName: 'Jaime', lastName: 'Vergara', team: 'South' },
+  { firstName: 'Jony', lastName: 'Baquedano Mendoza', team: 'South' },
+  { firstName: 'Jose', lastName: 'Fernandez', team: 'South' },
+  { firstName: 'Jose', lastName: 'Santos Diaz', team: 'South' },
+  { firstName: 'Joselin', lastName: 'Aguila', team: 'South' },
+  { firstName: 'Luis', lastName: 'Penaranda', team: 'South' },
+  { firstName: 'Moises', lastName: 'Varela', team: 'South' },
+  { firstName: 'Nicholas', lastName: 'Sieber', team: 'Central' },
+  { firstName: 'Noel', lastName: 'Venero', team: 'South' },
+  { firstName: 'Oscar', lastName: 'Hernandez', team: 'South' },
+  { firstName: 'Pedro', lastName: 'Manes', team: 'South' },
+  { firstName: 'Ramiro', lastName: 'Valle', team: 'South' },
+  { firstName: 'Robert', lastName: 'Amparo Lloret', team: 'South' },
+  { firstName: 'Robert', lastName: 'Gomez', team: 'South' },
+  { firstName: 'Troy', lastName: 'Sturgil', team: 'Central' },
+  { firstName: 'Ventura', lastName: 'Hernandez', team: 'South' },
+];
+
+const seedEmployees: Employee[] = seedData.map(e => ({
+  ...e,
+  id: toId(e.firstName, e.lastName),
+}));
+
+function sortEmployees(list: Employee[]): Employee[] {
+  return list.sort(
+    (a, b) =>
+      a.firstName.localeCompare(b.firstName) ||
+      a.lastName.localeCompare(b.lastName)
+  );
+}
+
+export function getEmployees(): Employee[] {
+  if (typeof window !== 'undefined') {
+    const raw = window.localStorage.getItem(LS_KEY);
+    if (raw) {
+      try {
+        const parsed: Employee[] = JSON.parse(raw);
+        return sortEmployees(parsed);
+      } catch {
+        // ignore
+      }
+    }
+  }
+  return sortEmployees([...seedEmployees]);
+}
+
+export function saveEmployees(list: Employee[]): void {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(LS_KEY, JSON.stringify(sortEmployees([...list])));
+  }
+}
+
+export function addEmployee(emp: Omit<Employee, 'id'>): void {
+  const list = getEmployees();
+  const next: Employee = { ...emp, id: toId(emp.firstName, emp.lastName) };
+  list.push(next);
+  saveEmployees(list);
+}
+
+export function updateEmployee(id: string, patch: Partial<Omit<Employee, 'id'>>): void {
+  const list = getEmployees();
+  const idx = list.findIndex(e => e.id === id);
+  if (idx >= 0) {
+    list[idx] = { ...list[idx], ...patch };
+    if (patch.firstName || patch.lastName) {
+      list[idx].id = toId(list[idx].firstName, list[idx].lastName);
+    }
+    saveEmployees(list);
+  }
+}
+
+export function deleteEmployee(id: string): void {
+  const list = getEmployees().filter(e => e.id !== id);
+  saveEmployees(list);
+}
+
+export function resetEmployees(): void {
+  if (typeof window !== 'undefined') {
+    window.localStorage.removeItem(LS_KEY);
+  }
+}
+


### PR DESCRIPTION
## Summary
- seed employees module with localStorage-backed CRUD
- add EmployeeMultiSelect with availability warnings, team grouping, and keyboard support
- create example employee picker and employees CRUD pages with header navigation
- restore README to prevent binary diff
- fix seed data to generate employee ids at build time

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c09a515ea08320a1effc2fde7904ff