### PR TITLE
Streamlined employee tools with return path preservation

### DIFF
--- a/src/app/employees/page.tsx
+++ b/src/app/employees/page.tsx
@@ -2,10 +2,10 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import {
   getEmployees,
   addEmployee,
-  updateEmployee,
   deleteEmployee,
   resetEmployees,
   type Employee,
@@ -13,51 +13,24 @@ import {
 } from "../../employees";
 
 export default function EmployeesPage() {
+  const params = useSearchParams();
+  const back = params.get("from") || "/";
+
   const [employees, setEmployees] = useState<Employee[]>(getEmployees());
-  const [search, setSearch] = useState("");
-
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
+  const [name, setName] = useState("");
   const [team, setTeam] = useState<Team>("South");
-
-  const [editing, setEditing] = useState<string | null>(null);
-  const [editFirst, setEditFirst] = useState("");
-  const [editLast, setEditLast] = useState("");
-  const [editTeam, setEditTeam] = useState<Team>("South");
 
   const refresh = () => setEmployees(getEmployees());
 
-  const filtered = employees.filter((e) =>
-    `${e.firstName} ${e.lastName}`
-      .toLowerCase()
-      .includes(search.toLowerCase())
-  );
-
   function handleAdd(e: React.FormEvent) {
     e.preventDefault();
-    if (!firstName.trim() || !lastName.trim()) return;
-    addEmployee({ firstName: firstName.trim(), lastName: lastName.trim(), team });
-    setFirstName("");
-    setLastName("");
+    const parts = name.trim().split(/\s+/);
+    if (!parts.length) return;
+    const [first, ...rest] = parts;
+    addEmployee({ firstName: first, lastName: rest.join(" "), team });
+    setName("");
     setTeam("South");
     refresh();
-  }
-
-  function startEdit(emp: Employee) {
-    setEditing(emp.id);
-    setEditFirst(emp.firstName);
-    setEditLast(emp.lastName);
-    setEditTeam(emp.team);
-  }
-
-  function saveEdit(id: string) {
-    updateEmployee(id, { firstName: editFirst, lastName: editLast, team: editTeam });
-    setEditing(null);
-    refresh();
-  }
-
-  function cancelEdit() {
-    setEditing(null);
   }
 
   function remove(id: string) {
@@ -71,89 +44,46 @@ export default function EmployeesPage() {
   }
 
   return (
-    <main className="p-4 space-y-6 max-w-2xl mx-auto">
+    <main className="p-4 space-y-4 max-w-md mx-auto">
       <div className="flex items-center gap-2">
-        <Link href="/" className="btn">Back</Link>
+        <Link href={back} className="btn">
+          Back
+        </Link>
+        <button className="btn ghost ml-auto" onClick={reset}>
+          Reset
+        </button>
+      </div>
+      <form onSubmit={handleAdd} className="flex gap-2">
         <input
           type="text"
-          placeholder="Search"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          placeholder="First Last"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
           className="border px-3 py-2 rounded flex-1"
         />
-        <button className="btn ghost ml-auto" onClick={reset}>Reset to seed</button>
-      </div>
-      <form onSubmit={handleAdd} className="bg-white rounded shadow p-4 flex flex-col sm:flex-row gap-4 items-end">
-        <div className="flex flex-col flex-1">
-          <label className="text-sm mb-1">First name</label>
-          <input
-            className="border rounded px-3 py-2"
-            value={firstName}
-            onChange={(e) => setFirstName(e.target.value)}
-          />
-        </div>
-        <div className="flex flex-col flex-1">
-          <label className="text-sm mb-1">Last name</label>
-          <input
-            className="border rounded px-3 py-2"
-            value={lastName}
-            onChange={(e) => setLastName(e.target.value)}
-          />
-        </div>
-        <div className="flex flex-col">
-          <label className="text-sm mb-1">Team</label>
-          <select
-            className="border rounded px-3 py-2"
-            value={team}
-            onChange={(e) => setTeam(e.target.value as Team)}
-          >
-            <option value="South">South</option>
-            <option value="Central">Central</option>
-          </select>
-        </div>
-        <button type="submit" className="btn primary self-end">Add</button>
+        <select
+          className="border rounded px-3 py-2"
+          value={team}
+          onChange={(e) => setTeam(e.target.value as Team)}
+        >
+          <option value="South">South</option>
+          <option value="Central">Central</option>
+        </select>
+        <button type="submit" className="btn primary">
+          Add
+        </button>
       </form>
-      <ul className="space-y-2">
-        {filtered.map((e) => (
-          editing === e.id ? (
-            <li key={e.id} className="bg-white rounded shadow p-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-col sm:flex-row sm:gap-4 flex-1">
-                <input
-                  className="border rounded px-2 py-1 flex-1"
-                  value={editFirst}
-                  onChange={(ev) => setEditFirst(ev.target.value)}
-                />
-                <input
-                  className="border rounded px-2 py-1 flex-1"
-                  value={editLast}
-                  onChange={(ev) => setEditLast(ev.target.value)}
-                />
-                <select
-                  className="border rounded px-2 py-1"
-                  value={editTeam}
-                  onChange={(ev) => setEditTeam(ev.target.value as Team)}
-                >
-                  <option value="South">South</option>
-                  <option value="Central">Central</option>
-                </select>
-              </div>
-              <div className="flex gap-2">
-                <button className="btn" onClick={() => saveEdit(e.id)}>Save</button>
-                <button className="btn ghost" onClick={cancelEdit}>Cancel</button>
-              </div>
-            </li>
-          ) : (
-            <li key={e.id} className="bg-white rounded shadow p-4 flex items-center justify-between">
-              <div>
-                <p className="font-medium">{e.firstName} {e.lastName}</p>
-                <p className="text-sm text-gray-500">{e.team}</p>
-              </div>
-              <div className="flex gap-2">
-                <button className="btn" onClick={() => startEdit(e)}>Edit</button>
-                <button className="btn danger" onClick={() => remove(e.id)}>Delete</button>
-              </div>
-            </li>
-          )
+      <ul className="bg-white rounded shadow divide-y">
+        {employees.map((e) => (
+          <li key={e.id} className="p-2 flex items-center gap-2">
+            <span className="flex-1">
+              {e.firstName} {e.lastName}
+            </span>
+            <span className="text-sm text-gray-500">{e.team}</span>
+            <button className="btn danger" onClick={() => remove(e.id)}>
+              Delete
+            </button>
+          </li>
         ))}
       </ul>
     </main>

--- a/src/components/CalendarWithData.tsx
+++ b/src/components/CalendarWithData.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState, FormEvent, TouchEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, FormEvent, TouchEvent, Suspense } from 'react';
 import Link from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
@@ -32,6 +33,14 @@ const VENDOR_COLOR: Record<Vendor, string> = {
   JORGE: 'green',
   TONY: 'blue',
   CHRIS: 'orange',
+};
+
+const EmployeesLink = () => {
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const search = params.toString();
+  const href = `/employees?from=${encodeURIComponent(pathname + (search ? `?${search}` : ''))}`;
+  return <Link href={href} className="btn ml-auto">Employees</Link>;
 };
 
 const IconType = (props: any) => (
@@ -846,7 +855,9 @@ export default function CalendarWithData({ calendarId, initialYear, initialMonth
           </div>
           <button className="btn" onClick={() => setHolidayDialog(true)}>Holidays</button>
           <button className="btn" onClick={() => setWeatherDialog(true)}>Weather</button>
-          <Link href="/employees" className="btn ml-auto">Employees</Link>
+          <Suspense fallback={<span className="btn ml-auto">Employees</span>}>
+            <EmployeesLink />
+          </Suspense>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- simplify Employees page with quick-add form, compact list, and reset/back controls
- preserve calendar route on navigation via Suspense-wrapped Employees button
- use query parameter to return to originating calendar from Employees

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0abbe1efc83209cf9b4f3c5e823e6