### PR TITLE
feat: allow assigning employees to events

### DIFF
--- a/src/components/EmployeeMultiSelect.tsx
+++ b/src/components/EmployeeMultiSelect.tsx
@@ -101,27 +101,26 @@ export default function EmployeeMultiSelect({
     const disabled = busy && conflictPolicy === "disable";
     const selected = value.includes(e.id);
     const highlight = idx === active;
-    return (
+  return (
       <li
         key={e.id}
         role="option"
         aria-selected={selected}
         onMouseEnter={() => setActive(idx)}
         onClick={() => toggle(e.id, disabled)}
-        className={`px-2 py-1 flex items-center justify-between cursor-pointer ${highlight ? "bg-gray-100" : ""} ${disabled ? "opacity-50" : ""}`}
+        className={`emp-ms-option${highlight ? " active" : ""}${disabled ? " disabled" : ""}`}
       >
-        <div className="flex items-center gap-2">
+        <div className="emp-ms-option-left">
           <input
             type="checkbox"
             checked={selected}
             readOnly
             disabled={disabled}
-            className="mr-2"
           />
           <span>{e.firstName} {e.lastName}</span>
         </div>
         {busy && (
-          <span className="text-xs text-red-600">
+          <span className="emp-ms-busy">
             {conflictPolicy === "warn" ? "Busy (warn)" : "Busy"}
           </span>
         )}
@@ -140,12 +139,14 @@ export default function EmployeeMultiSelect({
   const listContent = groupByTeam ? (
     sections.map((s) => (
       <div key={s.title}>
-        <div className="px-2 py-1 text-xs text-gray-500">{s.title}</div>
-        <ul>{s.items.map((e) => renderRow(e, flat.indexOf(e)))}</ul>
+        <div className="emp-ms-section-title">{s.title}</div>
+        <ul className="emp-ms-grid">
+          {s.items.map((e) => renderRow(e, flat.indexOf(e)))}
+        </ul>
       </div>
     ))
   ) : (
-    <ul>{flat.map((e, idx) => renderRow(e, idx))}</ul>
+    <ul className="emp-ms-grid">{flat.map((e, idx) => renderRow(e, idx))}</ul>
   );
 
   const labelText = label && <label className="block text-sm mb-1">{label}</label>;
@@ -157,11 +158,11 @@ export default function EmployeeMultiSelect({
     : placeholder;
 
   return (
-    <div className="relative" ref={containerRef}>
+    <div className="emp-ms" ref={containerRef}>
       {labelText}
       <button
         type="button"
-        className="w-full border px-3 py-2 text-left rounded"
+        className="emp-ms-btn"
         aria-haspopup="listbox"
         aria-expanded={open}
         onClick={() => setOpen((o) => !o)}
@@ -169,28 +170,24 @@ export default function EmployeeMultiSelect({
         {buttonText}
       </button>
       {open && (
-        <div
-          className="absolute z-10 mt-1 w-full border bg-white rounded shadow"
-          role="listbox"
-          aria-multiselectable="true"
-        >
-          <div className="p-2 border-b">
+        <div className="emp-ms-menu" role="listbox" aria-multiselectable="true">
+          <div className="emp-ms-search">
             <input
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search"
-              className="w-full border px-2 py-1 rounded"
+              className="emp-ms-search-input"
             />
             <button
               type="button"
-              className="mt-2 text-sm text-blue-600"
+              className="emp-ms-clear"
               onClick={() => onChange([])}
             >
               Clear all
             </button>
           </div>
-          <div className="max-h-64 overflow-y-auto">{listContent}</div>
+          <div className="emp-ms-options">{listContent}</div>
         </div>
       )}
     </div>

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -106,6 +106,77 @@
 .shift-toggle.night { background: var(--elev-2); }
 .form-grid input, .form-grid select, .form-grid textarea, .shift-toggle { min-height: 44px; }
 
+/* Employee multi-select */
+.emp-ms { position: relative; }
+.emp-ms-btn {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.55rem 0.65rem;
+  background: var(--card-2);
+  color: var(--text);
+  text-align: left;
+}
+.emp-ms-menu {
+  position: absolute;
+  z-index: 20;
+  margin-top: 0.25rem;
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--card-2);
+  box-shadow: 0 12px 30px rgba(0,0,0,.45);
+}
+.emp-ms-search {
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+.emp-ms-search-input {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.35rem 0.5rem;
+  background: var(--card);
+  color: var(--text);
+}
+.emp-ms-clear {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--primary);
+}
+.emp-ms-options {
+  max-height: 16rem;
+  overflow-y: auto;
+  padding: 0.25rem 0.5rem;
+}
+.emp-ms-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.25rem 0.5rem;
+}
+.emp-ms-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.25rem;
+  padding: 0.25rem 0.4rem;
+  cursor: pointer;
+  border-radius: 8px;
+}
+.emp-ms-option.active { background: var(--elev-2); }
+.emp-ms-option.disabled { opacity: 0.5; cursor: default; }
+.emp-ms-option-left { display: flex; align-items: center; gap: 0.25rem; }
+.emp-ms-option-left input { margin-right: 0.25rem; }
+.emp-ms-busy { font-size: 0.75rem; color: var(--danger); }
+.emp-ms-section-title {
+  padding: 0.25rem 0.4rem;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+
 /* ===== Day Weather (tiny, next to date) ===== */
 .fc .day-weather { margin-left: 2px; margin-right: 0; font-size: 0.72rem; color: var(--text-dim); text-decoration: none; display: inline-flex; gap: 4px; align-items: center; opacity: .95; }
 .fc .day-weather:hover { text-decoration: underline; color: var(--text); }


### PR DESCRIPTION
## Summary
- allow selecting employees when creating or editing an event
- store chosen employees in event checklist data
- style employee picker to match modal UI and show options in three columns

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0d1ce57988320a7ec55daf879e5b7