### PR TITLE
feat: redesign employees screen with material 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-leaflet": "^4.2.1",
+        "react-window": "^1.8.11",
         "studio": "^0.13.5"
       },
       "devDependencies": {
@@ -4309,6 +4310,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -4765,6 +4772,23 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-leaflet": "^4.2.1",
+    "react-window": "^1.8.11",
     "studio": "^0.13.5"
   },
   "devDependencies": {

--- a/src/app/example-employee-picker/page.tsx
+++ b/src/app/example-employee-picker/page.tsx
@@ -4,81 +4,12 @@ import { useState } from "react";
 import EmployeeMultiSelect from "../../components/EmployeeMultiSelect";
 import { getEmployees } from "../../employees";
 
-const busyMap: Record<string, string[]> = {
-  "2024-05-01": ["edilberto-acuna"],
-  "2024-05-02": ["christopher-jones", "troy-sturgil"],
-};
-
 export default function ExampleEmployeePicker() {
-  const [date, setDate] = useState("");
-  const [policy, setPolicy] = useState<"warn" | "disable">("warn");
-  const [group, setGroup] = useState(false);
   const [selected, setSelected] = useState<string[]>([]);
-
   const employees = getEmployees();
-  const assigned = busyMap[date] || [];
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    alert(`Saved ${selected.length} employees`);
-  }
-
   return (
-    <main className="p-4">
-      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
-        <div>
-          <label className="block text-sm mb-1">Date</label>
-          <input
-            type="date"
-            value={date}
-            onChange={(e) => setDate(e.target.value)}
-            className="border px-2 py-1 rounded w-full"
-          />
-        </div>
-        <div>
-          <label className="block text-sm mb-1">Conflict policy</label>
-          <select
-            value={policy}
-            onChange={(e) => setPolicy(e.target.value as any)}
-            className="border px-2 py-1 rounded w-full"
-          >
-            <option value="warn">warn</option>
-            <option value="disable">disable</option>
-          </select>
-        </div>
-        <div className="flex items-center gap-2">
-          <input
-            id="group"
-            type="checkbox"
-            checked={group}
-            onChange={(e) => setGroup(e.target.checked)}
-          />
-          <label htmlFor="group">Group by team</label>
-        </div>
-        <EmployeeMultiSelect
-          employees={employees}
-          value={selected}
-          onChange={setSelected}
-          assignedEmployeeIds={assigned}
-          conflictPolicy={policy}
-          groupByTeam={group}
-          label="Employees"
-        />
-        <div>
-          <h2 className="text-sm font-semibold">Selected</h2>
-          <ul className="list-disc pl-4">
-            {selected.map((id) => {
-              const emp = employees.find((e) => e.id === id);
-              if (!emp) return null;
-              return (
-                <li key={id}>{emp.firstName} {emp.lastName}</li>
-              );
-            })}
-          </ul>
-        </div>
-        <button type="submit" className="btn primary">Save</button>
-      </form>
+    <main style={{ padding: 16 }}>
+      <EmployeeMultiSelect employees={employees} value={selected} onChange={setSelected} label="Employees" />
     </main>
   );
 }
-

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import 'leaflet/dist/leaflet.css';
+import Providers from "./providers";
 
 export const metadata: Metadata = {
   title: "GFC Calendar",
@@ -11,7 +12,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { ThemeProvider, CssBaseline } from "@mui/material";
+import { createAppTheme, type Accent } from "../theme";
+
+interface AccentCtx {
+  accent: Accent;
+  setAccent: (a: Accent) => void;
+}
+
+const AccentColorContext = createContext<AccentCtx>({ accent: "forest", setAccent: () => {} });
+
+export function useAccentColor() {
+  return useContext(AccentColorContext);
+}
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  const [accent, setAccent] = useState<Accent>("forest");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("accent-color");
+    if (stored === "forest" || stored === "blue" || stored === "gray") {
+      setAccent(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem("accent-color", accent);
+  }, [accent]);
+
+  const theme = useMemo(() => createAppTheme(accent), [accent]);
+
+  return (
+    <AccentColorContext.Provider value={{ accent, setAccent }}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </AccentColorContext.Provider>
+  );
+}

--- a/src/components/AccentColorSelect.tsx
+++ b/src/components/AccentColorSelect.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
+import { ACCENT_PRESETS, type Accent } from "../theme";
+import { useAccentColor } from "../app/providers";
+
+export default function AccentColorSelect() {
+  const { accent, setAccent } = useAccentColor();
+  return (
+    <FormControl size="small">
+      <InputLabel id="accent-select-label">Accent color</InputLabel>
+      <Select
+        labelId="accent-select-label"
+        label="Accent color"
+        value={accent}
+        onChange={(e) => setAccent(e.target.value as Accent)}
+      >
+        {ACCENT_PRESETS.map((p) => (
+          <MenuItem key={p.value} value={p.value}>
+            {p.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,0 +1,67 @@
+import { createTheme, ThemeOptions } from '@mui/material/styles';
+import { PaletteColorOptions } from '@mui/material';
+
+export type Accent = 'forest' | 'blue' | 'gray';
+
+const ACCENTS: Record<Accent, { primary: string; primaryContainer: string; secondary: string; tertiary: string }> = {
+  forest: {
+    primary: '#1B5E20',
+    primaryContainer: '#0D2B12',
+    secondary: '#2E7D32',
+    tertiary: '#4CAF50',
+  },
+  blue: {
+    primary: '#0D47A1',
+    primaryContainer: '#082567',
+    secondary: '#1976D2',
+    tertiary: '#64B5F6',
+  },
+  gray: {
+    primary: '#37474F',
+    primaryContainer: '#1C2529',
+    secondary: '#607D8B',
+    tertiary: '#B0BEC5',
+  },
+};
+
+export function createAppTheme(accent: Accent) {
+  const tones = ACCENTS[accent];
+  const options: ThemeOptions = {
+    palette: {
+      mode: 'dark',
+      primary: {
+        main: tones.primary,
+        contrastText: '#FFFFFF',
+      },
+      secondary: {
+        main: tones.secondary,
+      },
+      error: {
+        main: '#B3261E',
+      },
+      background: {
+        default: '#1B1B1F',
+        paper: '#1F1F1F',
+      },
+      divider: '#2C2C2C',
+    },
+    shape: {
+      borderRadius: 8,
+    },
+    typography: {
+      // Using Material 3 typographic names if available
+      // Fallback to defaults otherwise
+      fontFamily: 'Roboto, sans-serif',
+    },
+  };
+  // Cast to any to allow additional M3 tokens like primaryContainer
+  (options.palette as any).primaryContainer = tones.primaryContainer;
+  (options.palette as any).tertiary = { main: tones.tertiary } as PaletteColorOptions;
+  return createTheme(options);
+}
+
+export const ACCENT_PRESETS: { label: string; value: Accent }[] = [
+  { label: 'Forest Green', value: 'forest' },
+  { label: 'Blue', value: 'blue' },
+  { label: 'Gray', value: 'gray' },
+];


### PR DESCRIPTION
## Summary
- add Material 3 dark theme with switchable accent colors
- redesign employees list with compact rows and delete actions
- replace employee multi-select with M3 Autocomplete and chips

## Testing
- `npm test`
- `npm run build` *(fails: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c1699a763083209ab3f8de7cc34de7