### PR TITLE
Add react-window type declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@types/node": "24.2.1",
         "@types/react": "19.1.10",
         "@types/react-dom": "^19.1.7",
+        "@types/react-window": "^1.8.8",
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
         "prisma": "^6.15.0",
@@ -3310,6 +3311,16 @@
       "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
       "license": "MIT",
       "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "@types/react": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/node": "24.2.1",
     "@types/react": "19.1.10",
     "@types/react-dom": "^19.1.7",
+    "@types/react-window": "^1.8.8",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "prisma": "^6.15.0",


### PR DESCRIPTION
## Summary
- fix TypeScript build error by adding @types/react-window

## Testing
- `npm test`
- `npm run build` *(fails: Type '"headlineSmall"' is not assignable to type 'OverridableStringUnion<"inherit" | TypographyVariant, TypographyPropsVariantOverrides> | undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68c1713b92848320aea287c21cb2663f