### PR TITLE
feat: apply material3 dark theme redesign

### DIFF
--- a/src/app/employees/page.tsx
+++ b/src/app/employees/page.tsx
@@ -22,8 +22,8 @@ import {
   Typography,
   TextField,
   InputAdornment,
-  Select,
   MenuItem,
+  Select,
   Button,
   Box,
   List,
@@ -46,6 +46,7 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
+import PersonOffIcon from "@mui/icons-material/PersonOff";
 
 function initials(e: Employee) {
   return `${e.firstName[0] ?? ""}${e.lastName[0] ?? ""}`.toUpperCase();
@@ -156,7 +157,7 @@ function EmployeesPageContent() {
           <Typography
             variant="h5"
             component="h1"
-            sx={{ flexGrow: 1, textAlign: "center" }}
+            sx={{ flexGrow: 1, textAlign: "center", typography: "titleLarge" }}
           >
             Employees
           </Typography>
@@ -187,15 +188,17 @@ function EmployeesPageContent() {
             ),
           }}
         />
-        <Select
+        <TextField
+          select
           size="small"
+          label="Team"
           value={teamFilter}
           onChange={(e) => setTeamFilter(e.target.value as Team | "All")}
         >
           <MenuItem value="All">All</MenuItem>
           <MenuItem value="South">South</MenuItem>
           <MenuItem value="Central">Central</MenuItem>
-        </Select>
+        </TextField>
         <Button
           startIcon={<AddIcon />}
           variant="contained"
@@ -208,10 +211,11 @@ function EmployeesPageContent() {
 
       {filtered.length === 0 ? (
         <Box sx={{ textAlign: "center", py: 6 }}>
-          <Typography variant="headlineSmall" gutterBottom>
+          <PersonOffIcon sx={{ fontSize: 48, mb: 1, color: "text.secondary" }} />
+          <Typography variant="h6" sx={{ typography: "headlineSmall" }} gutterBottom>
             No employees yet
           </Typography>
-          <Typography variant="bodyMedium" gutterBottom>
+          <Typography variant="body2" sx={{ typography: "bodyMedium" }} gutterBottom>
             Add an employee to get started.
           </Typography>
           <Button variant="contained" onClick={openAdd}>
@@ -219,73 +223,76 @@ function EmployeesPageContent() {
           </Button>
         </Box>
       ) : filtered.length > 200 ? (
-        <FixedSizeList
-          height={Math.min(400, filtered.length * 56)}
-          itemCount={filtered.length}
-          itemSize={56}
-          width="100%"
-        >
-          {({ index, style }: ListChildComponentProps) => {
-            const e = filtered[index];
-            return (
-              <div style={style} key={e.id}>
-                <ListItem
-                  disablePadding
-                  secondaryAction={
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                      <Typography variant="bodyMedium" color="text.secondary">
-                        ({e.team})
-                      </Typography>
-                      <Tooltip title="Delete">
-                        <IconButton
-                          edge="end"
-                          aria-label={`Delete ${e.firstName} ${e.lastName}`}
-                          sx={{ color: "text.secondary", "&:hover": { color: "error.main" } }}
-                          onClick={() => setToDelete(e)}
-                        >
-                          <DeleteIcon />
-                        </IconButton>
-                      </Tooltip>
-                    </Box>
-                  }
-                >
-                  <ListItemButton
-                    sx={{ py: 1, "&.Mui-focusVisible": { outline: (theme) => `2px solid ${theme.palette.primary.main}` } }}
-                    aria-label={`Open employee ${e.firstName} ${e.lastName}`}
+        <Box sx={{ bgcolor: (theme) => (theme.palette as any).surfaceContainerLow }}>
+          <FixedSizeList
+            height={Math.min(400, filtered.length * 56)}
+            itemCount={filtered.length}
+            itemSize={56}
+            width="100%"
+          >
+            {({ index, style }: ListChildComponentProps) => {
+              const e = filtered[index];
+              return (
+                <div style={style} key={e.id}>
+                  <ListItem
+                    disablePadding
+                    secondaryAction={
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                        <Typography variant="body2" sx={{ typography: "bodyMedium" }} color="text.secondary">
+                          ({e.team})
+                        </Typography>
+                        <Tooltip title="Delete">
+                          <IconButton
+                            edge="end"
+                            aria-label={`Delete ${e.firstName} ${e.lastName}`}
+                            sx={{ color: "text.secondary", "&:hover": { color: "error.main" } }}
+                            onClick={() => setToDelete(e)}
+                          >
+                            <DeleteIcon />
+                          </IconButton>
+                        </Tooltip>
+                      </Box>
+                    }
                   >
-                    <ListItemAvatar>
-                      <Avatar sx={{ width: 32, height: 32, fontSize: 14, bgcolor: "background.paper", color: "text.secondary" }}>
-                        {initials(e)}
-                      </Avatar>
-                    </ListItemAvatar>
-                    <ListItemText
-                      primary={`${e.firstName} ${e.lastName}`}
-                      primaryTypographyProps={{
-                        variant: "bodyMedium",
-                        sx: {
-                          color: (theme) => alpha(theme.palette.primary.main, 0.9),
-                          whiteSpace: "nowrap",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                        },
-                      }}
-                    />
-                  </ListItemButton>
-                </ListItem>
-                <Divider component="li" />
-              </div>
-            );
-          }}
-        </FixedSizeList>
+                    <ListItemButton
+                      sx={{ py: 1, "&.Mui-focusVisible": { outline: (theme) => `2px solid ${theme.palette.primary.main}` } }}
+                      aria-label={`Open employee ${e.firstName} ${e.lastName} (${e.team})`}
+                    >
+                      <ListItemAvatar>
+                        <Avatar sx={{ width: 32, height: 32, fontSize: 14, bgcolor: "background.paper", color: "text.secondary" }}>
+                          {initials(e)}
+                        </Avatar>
+                      </ListItemAvatar>
+                      <ListItemText
+                        primary={`${e.firstName} ${e.lastName}`}
+                        primaryTypographyProps={{
+                          variant: "body2",
+                          sx: {
+                            typography: "bodyMedium",
+                            color: (theme) => alpha(theme.palette.primary.main, 0.9),
+                            whiteSpace: "nowrap",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                          },
+                        }}
+                      />
+                    </ListItemButton>
+                  </ListItem>
+                  <Divider component="li" />
+                </div>
+              );
+            }}
+          </FixedSizeList>
+        </Box>
       ) : (
-        <List sx={{ bgcolor: "background.paper" }}>
+        <List sx={{ bgcolor: (theme) => (theme.palette as any).surfaceContainerLow }}>
           {filtered.map((e) => (
             <React.Fragment key={e.id}>
               <ListItem
                 disablePadding
                 secondaryAction={
                   <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                    <Typography variant="bodyMedium" color="text.secondary">
+                    <Typography variant="body2" sx={{ typography: "bodyMedium" }} color="text.secondary">
                       ({e.team})
                     </Typography>
                     <Tooltip title="Delete">
@@ -303,7 +310,7 @@ function EmployeesPageContent() {
               >
                 <ListItemButton
                   sx={{ py: 1, "&.Mui-focusVisible": { outline: (theme) => `2px solid ${theme.palette.primary.main}` } }}
-                  aria-label={`Open employee ${e.firstName} ${e.lastName}`}
+                  aria-label={`Open employee ${e.firstName} ${e.lastName} (${e.team})`}
                 >
                   <ListItemAvatar>
                     <Avatar sx={{ width: 32, height: 32, fontSize: 14, bgcolor: "background.paper", color: "text.secondary" }}>
@@ -313,8 +320,9 @@ function EmployeesPageContent() {
                   <ListItemText
                     primary={`${e.firstName} ${e.lastName}`}
                     primaryTypographyProps={{
-                      variant: "bodyMedium",
+                      variant: "body2",
                       sx: {
+                        typography: "bodyMedium",
                         color: (theme) => alpha(theme.palette.primary.main, 0.9),
                         whiteSpace: "nowrap",
                         overflow: "hidden",

--- a/src/components/EmployeeMultiSelect.tsx
+++ b/src/components/EmployeeMultiSelect.tsx
@@ -76,6 +76,7 @@ export default function EmployeeMultiSelect({ employees, value, onChange, placeh
   return (
     <Autocomplete
       multiple
+      size="small"
       options={employees}
       value={selected}
       disableCloseOnSelect
@@ -84,12 +85,16 @@ export default function EmployeeMultiSelect({ employees, value, onChange, placeh
       filterOptions={filterOptions}
       onChange={(_, next) => onChange(next.map((n) => n.id))}
       ListboxComponent={employees.length > 200 ? ListboxComponent : undefined}
+      slotProps={{
+        paper: { sx: { bgcolor: (theme) => (theme.palette as any).surfaceContainerLow } },
+      }}
       renderTags={(val, getTagProps) =>
         val.map((option, idx) => (
           <Chip
             {...getTagProps({ index: idx })}
             key={option.id}
             label={`${option.firstName} ${option.lastName}`}
+            size="small"
           />
         ))
       }
@@ -101,12 +106,12 @@ export default function EmployeeMultiSelect({ employees, value, onChange, placeh
               {option.lastName[0]}
             </Avatar>
             <Typography
-              variant="bodyMedium"
-              sx={{ flexGrow: 1, color: (theme) => alpha(theme.palette.primary.main, 0.9) }}
+              variant="body2"
+              sx={{ flexGrow: 1, typography: "bodyMedium", color: (theme) => alpha(theme.palette.primary.main, 0.9) }}
             >
               {option.firstName} {option.lastName}
             </Typography>
-            <Typography variant="bodyMedium" color="text.secondary">
+            <Typography variant="body2" sx={{ typography: "bodyMedium" }} color="text.secondary">
               ({option.team})
             </Typography>
           </Box>
@@ -117,6 +122,7 @@ export default function EmployeeMultiSelect({ employees, value, onChange, placeh
           {...params}
           label={label ?? "Select employees"}
           placeholder={placeholder}
+          size="small"
           InputProps={{
             ...params.InputProps,
             endAdornment: (

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -3,7 +3,15 @@ import { PaletteColorOptions } from '@mui/material';
 
 export type Accent = 'forest' | 'blue' | 'gray';
 
-const ACCENTS: Record<Accent, { primary: string; primaryContainer: string; secondary: string; tertiary: string }> = {
+const ACCENTS: Record<
+  Accent,
+  {
+    primary: string;
+    primaryContainer: string;
+    secondary: string;
+    tertiary: string;
+  }
+> = {
   forest: {
     primary: '#1B5E20',
     primaryContainer: '#0D2B12',
@@ -31,7 +39,7 @@ export function createAppTheme(accent: Accent) {
       mode: 'dark',
       primary: {
         main: tones.primary,
-        contrastText: '#FFFFFF',
+        contrastText: '#FFFFFF', // on primary
       },
       secondary: {
         main: tones.secondary,
@@ -40,8 +48,9 @@ export function createAppTheme(accent: Accent) {
         main: '#B3261E',
       },
       background: {
-        default: '#1B1B1F',
-        paper: '#1F1F1F',
+        // M3 dark surfaces
+        default: '#1B1B1F', // surface
+        paper: '#1F1F1F', // surfaceContainerLow
       },
       divider: '#2C2C2C',
     },
@@ -49,14 +58,19 @@ export function createAppTheme(accent: Accent) {
       borderRadius: 8,
     },
     typography: {
-      // Using Material 3 typographic names if available
-      // Fallback to defaults otherwise
       fontFamily: 'Roboto, sans-serif',
     },
   };
-  // Cast to any to allow additional M3 tokens like primaryContainer
-  (options.palette as any).primaryContainer = tones.primaryContainer;
-  (options.palette as any).tertiary = { main: tones.tertiary } as PaletteColorOptions;
+
+  // Add M3 custom palette tokens
+  const palette = options.palette as any;
+  palette.primaryContainer = tones.primaryContainer;
+  palette.tertiary = { main: tones.tertiary } as PaletteColorOptions;
+  palette.surface = '#1B1B1F';
+  palette.surfaceContainerLow = '#1F1F1F';
+  palette.outline = '#939094';
+  palette.outlineVariant = '#46464F';
+
   return createTheme(options);
 }
 


### PR DESCRIPTION
## Summary
- implement Material 3 dark theme with forest green accent and presets
- restyle Employees screen with compact list, search, team filter, and delete flow
- match Employee multi-select to list layout and accent color scheme

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c1739e14e88320a1f002f9e5ef651b