### PR TITLE
Add Prisma Accelerate dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@mui/icons-material": "^7.3.2",
         "@mui/material": "^7.3.2",
         "@prisma/client": "^6.15.0",
+        "@prisma/extension-accelerate": "^2.0.2",
         "chrono-node": "^2.7.5",
         "ical-generator": "^7.0.0",
         "leaflet": "^1.9.4",
@@ -3053,6 +3054,17 @@
       "integrity": "sha512-ThvlDaKIVrnrv97ujNFDYiQbeMQpLa0O86HFA2mNoip4mtFqM7U5GSz2ie1i2xByZtvPztJlNRgPsXGeM/kqAA==",
       "devOptional": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/extension-accelerate": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@prisma/extension-accelerate/-/extension-accelerate-2.0.2.tgz",
+      "integrity": "sha512-yZK6/k7uOEFpEsKoZezQS1CKDboPtBCQ0NyI70e1Un8tDiRgg80iWGyjsJmRpps2ZIut3MroHP+dyR3wVKh8lA==",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@prisma/client": ">=4.16.1"
+      }
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.16.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",
     "@prisma/client": "^6.15.0",
+    "@prisma/extension-accelerate": "^2.0.2",
     "chrono-node": "^2.7.5",
     "ical-generator": "^7.0.0",
     "leaflet": "^1.9.4",


### PR DESCRIPTION
## Summary
- fix build failure by installing missing @prisma/extension-accelerate dependency

## Testing
- `npm test`
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 DATABASE_URL="postgresql://user:pass@localhost:5432/db" DIRECT_DATABASE_URL="postgresql://user:pass@localhost:5432/db" npm run build` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/all_commits/1c57fdcd7e44b29b9313256c76699e91c3ac3c43/debian-openssl-3.0.x/schema-engine.gz - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bfd43b088320968bdb32a00c982e