### PR TITLE
fix: convert attachment bytes to ArrayBuffer

### DIFF
--- a/src/app/api/events/[id]/attachment/route.ts
+++ b/src/app/api/events/[id]/attachment/route.ts
@@ -35,9 +35,13 @@ export async function GET(
   // Prisma Edge returns Uint8Array for Bytes; cast defensively
   const data: any = ev.attachmentData
   const body = data instanceof Uint8Array ? data : new Uint8Array(data as ArrayBuffer);
+  const arrayBuffer = body.buffer.slice(
+    body.byteOffset,
+    body.byteOffset + body.byteLength,
+  ) as ArrayBuffer;
 
   const filename = (ev.attachmentName ?? "file").replace(/\//g, "");
-  return new Response(body, {
+  return new Response(arrayBuffer, {
     status: 200,
     headers: {
       "Content-Type": ev.attachmentType ?? "application/octet-stream",


### PR DESCRIPTION
## Summary
- ensure attachment API converts `Uint8Array` to `ArrayBuffer` before creating `Response`

## Testing
- `npm test`
- `npx next build` *(fails: InvalidDatasourceError - the URL must start with the protocol `prisma://` or `prisma+postgres://`)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d01139ec8320b0f90ce6295cb6ed