### PR TITLE
Fix customer import for Cloudflare edge runtime

### DIFF
--- a/src/lib/excel.ts
+++ b/src/lib/excel.ts
@@ -24,9 +24,14 @@ export async function writeWorkbook(options: {
   await wb.xlsx.writeFile(filePath)
 }
 
-export async function readFirstSheet(filePath: string) {
+export async function readFirstSheet(input: string | ArrayBuffer | Uint8Array) {
   const wb = new ExcelJS.Workbook()
-  await wb.xlsx.readFile(filePath)
+  if (typeof input === 'string') {
+    await wb.xlsx.readFile(input)
+  } else {
+    const data = input instanceof ArrayBuffer ? new Uint8Array(input) : input
+    await wb.xlsx.load(data)
+  }
   const ws = wb.worksheets[0]
   if (!ws) return []
 


### PR DESCRIPTION
## Summary
- parse uploaded Excel files in memory instead of writing to the filesystem
- allow `readFirstSheet` to read from a buffer for edge compatibility

## Testing
- `npm test`
- `npm run build` *(fails: Type error in my-calendar-main/src/lib/holidays.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c49f5333f48320af0e587d36f9cebb