### PR TITLE
Fix holiday data typing and remove unused TS directives

### DIFF
--- a/my-calendar-main/src/lib/holidays.ts
+++ b/my-calendar-main/src/lib/holidays.ts
@@ -57,15 +57,14 @@ export async function getHolidaysDb(
   start: Date,
   end: Date,
   countryCode: string,
-) {
-  type Result = Awaited<ReturnType<typeof prisma.holiday.findMany>>
-  return tryPrisma<Result>(
+): Promise<Holiday[]> {
+  return tryPrisma<Holiday[]>(
     () =>
       prisma.holiday.findMany({
         where: { date: { gte: start, lt: end }, countryCode },
         orderBy: { date: 'asc' },
       }),
-    [] as Result,
+    [] as Holiday[],
   )
 }
 

--- a/src/lib/excel.ts
+++ b/src/lib/excel.ts
@@ -12,7 +12,6 @@ export async function writeWorkbook(options: {
 
   if (rows.length > 0) {
     const columns = Object.keys(rows[0]).map((k) => ({ header: k, key: k }))
-    // @ts-expect-error ExcelJS types allow header/key pairs
     ws.columns = columns
     rows.forEach((r) => ws.addRow(r))
     ws.columns?.forEach((c: any) => {
@@ -30,7 +29,8 @@ export async function readFirstSheet(input: string | ArrayBuffer | Uint8Array) {
     await wb.xlsx.readFile(input)
   } else {
     const data = input instanceof ArrayBuffer ? new Uint8Array(input) : input
-    await wb.xlsx.load(data)
+    const buf = Buffer.from(data as Uint8Array)
+    await wb.xlsx.load(buf as any)
   }
   const ws = wb.worksheets[0]
   if (!ws) return []

--- a/src/lib/holidays.ts
+++ b/src/lib/holidays.ts
@@ -57,15 +57,14 @@ export async function getHolidaysDb(
   start: Date,
   end: Date,
   countryCode: string,
-) {
-  type Result = Awaited<ReturnType<typeof prisma.holiday.findMany>>
-  return tryPrisma<Result>(
+): Promise<Holiday[]> {
+  return tryPrisma<Holiday[]>(
     () =>
       prisma.holiday.findMany({
         where: { date: { gte: start, lt: end }, countryCode },
         orderBy: { date: 'asc' },
       }),
-    [] as Result,
+    [] as Holiday[],
   )
 }
 


### PR DESCRIPTION
## Summary
- ensure `getHolidaysDb` returns typed `Holiday[]` results for safe mapping
- clean up Excel helper to satisfy TypeScript without suppressed errors

## Testing
- `npm test`
- `DATABASE_URL="postgres://user:pass@localhost:5432/db" npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4a264c5a0832097a05fa249c23932