### PR TITLE
Fix react-window import for type compatibility

### DIFF
--- a/src/app/employees/page.tsx
+++ b/src/app/employees/page.tsx
@@ -12,7 +12,7 @@ import {
   type Team,
 } from "../../employees";
 import { alpha } from "@mui/material/styles";
-import { FixedSizeList, ListChildComponentProps } from "react-window";
+import * as ReactWindow from "react-window";
 import AccentColorSelect from "../../components/AccentColorSelect";
 
 import {
@@ -47,6 +47,9 @@ import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
 import PersonOffIcon from "@mui/icons-material/PersonOff";
+
+const FixedSizeList = ReactWindow.FixedSizeList;
+type ListChildComponentProps = ReactWindow.ListChildComponentProps;
 
 function initials(e: Employee) {
   return `${e.firstName[0] ?? ""}${e.lastName[0] ?? ""}`.toUpperCase();

--- a/src/components/EmployeeMultiSelect.tsx
+++ b/src/components/EmployeeMultiSelect.tsx
@@ -11,8 +11,11 @@ import {
   Button,
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
-import { FixedSizeList, ListChildComponentProps } from "react-window";
+import * as ReactWindow from "react-window";
 import type { Employee } from "../employees";
+
+const FixedSizeList = ReactWindow.FixedSizeList;
+type ListChildComponentProps = ReactWindow.ListChildComponentProps;
 
 interface Props {
   employees: Employee[];


### PR DESCRIPTION
## Summary
- adjust react-window imports to namespace form so FixedSizeList resolves in bundler module resolution

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find name 'describe')*

------
https://chatgpt.com/codex/tasks/task_e_68c5a749d1348320947b13e0aa243966