### PR TITLE
Handle missing database env in Prisma helpers

### DIFF
--- a/my-calendar-main/src/app/api/calendars/[id]/share/route.ts
+++ b/my-calendar-main/src/app/api/calendars/[id]/share/route.ts
@@ -1,18 +1,21 @@
 import { NextResponse } from "next/server";
 import { prisma, tryPrisma } from "@/lib/dbSafe";
+import type { ShareToken } from "@prisma/client";
 
 export async function GET(
   _req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params; // Next 15: await params
-  const tokens = await tryPrisma(() =>
-    prisma.shareToken.findMany({
-      where: { calendarId: id },
-      orderBy: { createdAt: "desc" },
-      take: 20,
-    })
-  , []);
+  const tokens = await tryPrisma<ShareToken[]>(
+    () =>
+      prisma.shareToken.findMany({
+        where: { calendarId: id },
+        orderBy: { createdAt: "desc" },
+        take: 20,
+      }),
+    [] as ShareToken[]
+  );
   return NextResponse.json(tokens);
 }
 

--- a/my-calendar-main/src/lib/db.ts
+++ b/my-calendar-main/src/lib/db.ts
@@ -4,13 +4,8 @@
 import { PrismaClient } from '@prisma/client/edge'
 import { withAccelerate } from '@prisma/extension-accelerate'
 
-function requireEnv(name: string): string {
-  const v = process.env[name]
-  if (!v) throw new Error(`Missing env ${name}`)
-  return v
-}
+const url = process.env.DATABASE_URL
 
-// DATABASE_URL must be a Prisma Accelerate/Data Proxy URL (starts with prisma://)
-export const prisma = new PrismaClient({
-  datasourceUrl: requireEnv('DATABASE_URL'),
-}).$extends(withAccelerate())
+export const prisma = url
+  ? (new PrismaClient({ datasourceUrl: url }).$extends(withAccelerate()) as any)
+  : ({} as any)

--- a/my-calendar-main/src/lib/dbSafe.ts
+++ b/my-calendar-main/src/lib/dbSafe.ts
@@ -17,6 +17,11 @@ const CHECK_TTL_MS = 60000
 async function checkDbAvailable(): Promise<boolean> {
   const now = Date.now()
   if (cachedAvailable !== null && now - lastCheck < CHECK_TTL_MS) return cachedAvailable
+  if (!process.env.DATABASE_URL) {
+    cachedAvailable = false
+    lastCheck = now
+    return false
+  }
   try {
     await prisma.$queryRawUnsafe("SELECT 1")
     cachedAvailable = true

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -3,16 +3,14 @@
 
 import { withAccelerate } from '@prisma/extension-accelerate'
 
-function requireEnv(name: string): string {
-  const v = process.env[name]
-  if (!v) throw new Error(`Missing env ${name}`)
-  return v
+const url = process.env.DATABASE_URL
+let prisma: any
+if (url) {
+  prisma = url.startsWith('prisma://')
+    ? new (await import('@prisma/client/edge')).PrismaClient({ datasourceUrl: url }).$extends(withAccelerate())
+    : new (await import('@prisma/client')).PrismaClient({ datasources: { db: { url } } })
+} else {
+  prisma = {}
 }
-
-const url = requireEnv('DATABASE_URL')
-
-const prisma = url.startsWith('prisma://')
-  ? new (await import('@prisma/client/edge')).PrismaClient({ datasourceUrl: url }).$extends(withAccelerate())
-  : new (await import('@prisma/client')).PrismaClient({ datasources: { db: { url } } })
 
 export { prisma }

--- a/src/lib/dbSafe.ts
+++ b/src/lib/dbSafe.ts
@@ -17,6 +17,11 @@ const CHECK_TTL_MS = 60000
 async function checkDbAvailable(): Promise<boolean> {
   const now = Date.now()
   if (cachedAvailable !== null && now - lastCheck < CHECK_TTL_MS) return cachedAvailable
+  if (!process.env.DATABASE_URL) {
+    cachedAvailable = false
+    lastCheck = now
+    return false
+  }
   try {
     // Lightweight connectivity probe
     await prisma.$queryRaw`SELECT 1`


### PR DESCRIPTION
## Summary
- avoid runtime crashes when `DATABASE_URL` is absent by exporting stub Prisma client
- skip database checks when no connection string is configured
- fix share token listing route type inference

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5f9269fb083209c9a970cd355f57c