### PR TITLE
Handle missing database URL in Prisma helper

### DIFF
--- a/src/lib/dbSafe.ts
+++ b/src/lib/dbSafe.ts
@@ -1,13 +1,29 @@
 // src/lib/dbSafe.ts
 import { getPrisma } from './db'
 
+const DB_UNAVAILABLE_MESSAGES = [
+  "Can't reach database server",
+  'Environment variable not found: DATABASE_URL',
+  'Missing DATABASE_URL',
+]
+
+function isDatabaseUnavailable(error: any): boolean {
+  const msg = String(error?.message ?? '')
+  if (!msg && error?.code === 'P1001') return true
+  if (error?.code === 'P1001') return true
+  return DB_UNAVAILABLE_MESSAGES.some(fragment => (fragment ? msg.includes(fragment) : false))
+}
+
 export async function tryPrisma<T>(thunk: (p: any) => Promise<T>, fallback: T): Promise<T> {
+  if (!process.env.DATABASE_URL || !String(process.env.DATABASE_URL).trim()) {
+    return fallback
+  }
+
   try {
     const p = await getPrisma()
     return await thunk(p)
   } catch (e: any) {
-    const msg = String(e?.message ?? '')
-    if (msg.includes("Can't reach database server") || e?.code === 'P1001') return fallback
+    if (isDatabaseUnavailable(e)) return fallback
     throw e
   }
 }


### PR DESCRIPTION
## Summary
- guard tryPrisma against missing DATABASE_URL values so development without Postgres falls back cleanly
- treat Prisma initialization errors referencing DATABASE_URL as database unavailability when computing fallbacks

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ca08e5c5fc8320b5710cc590fd348e