### PR TITLE
Add FDOT cut-off management and reporting

### DIFF
--- a/prisma/migrations/20251001000000_fdot_cutoffs/migration.sql
+++ b/prisma/migrations/20251001000000_fdot_cutoffs/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "public"."fdot_cutoffs" (
+    "id" TEXT PRIMARY KEY,
+    "year" INTEGER NOT NULL,
+    "cutoff_date" TIMESTAMP(3) NOT NULL,
+    "label" TEXT,
+    "created_by" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "fdot_cutoffs_year_cutoff_date_key"
+  ON "public"."fdot_cutoffs" ("year", "cutoff_date");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -199,3 +199,16 @@ enum WeeklyStatus {
   SUCCESS
   ERROR
 }
+
+model FdotCutoff {
+  id         String   @id @default(cuid())
+  year       Int
+  cutoffDate DateTime @map("cutoff_date")
+  label      String?
+  createdBy  String?  @map("created_by")
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
+
+  @@unique([year, cutoffDate])
+  @@map("fdot_cutoffs")
+}

--- a/src/app/admin/fdot-cutoffs/page.tsx
+++ b/src/app/admin/fdot-cutoffs/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const FdotCutoffManager = dynamic(() => import('@/components/admin/FdotCutoffManager'), { ssr: false })
+
+export default function FdotCutoffsPage() {
+  return (
+    <div style={{ padding: '2rem 1.5rem' }}>
+      <FdotCutoffManager />
+    </div>
+  )
+}

--- a/src/app/api/fdot-cutoffs/[year]/route.ts
+++ b/src/app/api/fdot-cutoffs/[year]/route.ts
@@ -1,0 +1,64 @@
+// src/app/api/fdot-cutoffs/[year]/route.ts
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+import { NextRequest, NextResponse } from 'next/server'
+import { fetchCutoffsForYear, saveCutoffs } from '@/server/fdotCutoffs'
+
+async function readJson(req: NextRequest): Promise<any | null> {
+  try {
+    const json = await req.json()
+    if (json && typeof json === 'object') return json
+  } catch {}
+  return null
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { year: string } },
+) {
+  const year = Number.parseInt(params?.year ?? '', 10)
+  if (!Number.isFinite(year)) {
+    return NextResponse.json({ error: 'Invalid year' }, { status: 400 })
+  }
+  const cutoffs = await fetchCutoffsForYear(year)
+  return NextResponse.json({ year, cutoffs })
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { year: string } },
+) {
+  const year = Number.parseInt(params?.year ?? '', 10)
+  if (!Number.isFinite(year)) {
+    return NextResponse.json({ error: 'Invalid year' }, { status: 400 })
+  }
+  const body = await readJson(req)
+  if (!body || !Array.isArray(body.cutoffs)) {
+    return NextResponse.json({ error: 'cutoffs array required' }, { status: 400 })
+  }
+
+  try {
+    const result = await saveCutoffs(year, body.cutoffs, req.headers.get('x-user-id'))
+    console.log('telemetry:fdot_cutoffs.save', {
+      userId: req.headers.get('x-user-id') ?? null,
+      year,
+      created: result.created,
+      updated: result.updated,
+      deleted: result.deleted,
+    })
+    return NextResponse.json({
+      year,
+      cutoffs: result.records,
+      summary: {
+        created: result.created,
+        updated: result.updated,
+        deleted: result.deleted,
+      },
+    })
+  } catch (error: any) {
+    const status = Number.isFinite(error?.status) ? Number(error.status) : 400
+    return NextResponse.json({ error: String(error?.message || 'Failed to save cut-offs') }, { status })
+  }
+}

--- a/src/app/api/fdot-cutoffs/route.ts
+++ b/src/app/api/fdot-cutoffs/route.ts
@@ -1,0 +1,22 @@
+// src/app/api/fdot-cutoffs/route.ts
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+import { NextRequest, NextResponse } from 'next/server'
+import { fetchAllCutoffs, fetchCutoffYears, fetchCutoffsForYear } from '@/server/fdotCutoffs'
+
+export async function GET(req: NextRequest) {
+  const yearParam = req.nextUrl.searchParams.get('year')
+  if (yearParam) {
+    const year = Number.parseInt(yearParam, 10)
+    if (!Number.isFinite(year)) {
+      return NextResponse.json({ error: 'Invalid year parameter' }, { status: 400 })
+    }
+    const cutoffs = await fetchCutoffsForYear(year)
+    return NextResponse.json({ year, cutoffs })
+  }
+
+  const [years, grouped] = await Promise.all([fetchCutoffYears(), fetchAllCutoffs()])
+  return NextResponse.json({ years, cutoffs: grouped })
+}

--- a/src/app/api/reports/fdot-cutoff/route.ts
+++ b/src/app/api/reports/fdot-cutoff/route.ts
@@ -1,0 +1,90 @@
+// src/app/api/reports/fdot-cutoff/route.ts
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  exportAggregatedCsv,
+  generateAggregatedRows,
+  resolveCutoffWindow,
+} from '@/server/fdotCutoffs'
+
+async function readJson(req: NextRequest): Promise<any | null> {
+  try {
+    const json = await req.json()
+    if (json && typeof json === 'object') return json
+  } catch {}
+  return null
+}
+
+export async function POST(req: NextRequest) {
+  const body = await readJson(req)
+  if (!body) {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const year = Number.parseInt(String(body.year ?? ''), 10)
+  if (!Number.isFinite(year)) {
+    return NextResponse.json({ error: 'year is required' }, { status: 400 })
+  }
+
+  const toCutoff = String(body.toCutoff ?? body.toCutoffId ?? '').trim()
+  if (!toCutoff) {
+    return NextResponse.json({ error: 'toCutoff is required' }, { status: 400 })
+  }
+
+  const window = await resolveCutoffWindow(year, toCutoff)
+  if (!window) {
+    return NextResponse.json({ error: 'Unable to resolve cut-off window' }, { status: 404 })
+  }
+
+  const format = String(body.format ?? 'json').toLowerCase()
+  const page = Number.parseInt(String(body.page ?? '1'), 10)
+  const pageSize = Number.parseInt(String(body.pageSize ?? '1000'), 10)
+
+  if (format === 'csv') {
+    const { csv, rowCount } = await exportAggregatedCsv(window)
+    console.log('telemetry:fdot_report.generate', {
+      userId: req.headers.get('x-user-id') ?? null,
+      year,
+      toCutoff: window.toCutoff.cutoffDate,
+      format: 'csv',
+      rows: rowCount,
+    })
+    return new NextResponse(csv, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="fdot-cutoff-${window.endDate}.csv"`,
+        'Cache-Control': 'no-store',
+      },
+    })
+  }
+
+  const result = await generateAggregatedRows(window, page, pageSize)
+  console.log('telemetry:fdot_report.generate', {
+    userId: req.headers.get('x-user-id') ?? null,
+    year,
+    toCutoff: window.toCutoff.cutoffDate,
+    format: 'json',
+    rows: result.totalRows,
+    page: result.page,
+    pageSize: result.pageSize,
+  })
+
+  return NextResponse.json({
+    window: {
+      startDate: window.startDate,
+      endDate: window.endDate,
+      toCutoff: window.toCutoff,
+      previousCutoff: window.previousCutoff,
+    },
+    page: result.page,
+    pageSize: result.pageSize,
+    totalRows: result.totalRows,
+    rows: result.rows,
+    jobTotals: result.jobTotals,
+    grandTotal: result.grandTotal,
+  })
+}

--- a/src/app/api/reports/quantities/route.ts
+++ b/src/app/api/reports/quantities/route.ts
@@ -74,7 +74,23 @@ export async function GET(req: NextRequest) {
     [] as any[],
   )
 
-  const data = rows.map((row: any) => ({
+  const startMs = from.getTime()
+  const endMs = toExclusive.getTime()
+  const customerNeedle = customerRaw.toLowerCase()
+
+  const filtered = rows.filter((row: any) => {
+    const eventStart = row.event?.startsAt ? new Date(row.event.startsAt).getTime() : NaN
+    if (!Number.isFinite(eventStart)) return false
+    if (eventStart < startMs || eventStart >= endMs) return false
+    if (calendarId && row.event?.calendarId !== calendarId) return false
+    if (customerNeedle) {
+      const title = String(row.event?.title ?? '').toLowerCase()
+      if (!title.includes(customerNeedle)) return false
+    }
+    return true
+  })
+
+  const data = filtered.map((row: any) => ({
     eventId: row.event?.id ?? '',
     eventDate: row.event?.startsAt ? new Date(row.event.startsAt).toISOString() : '',
     eventTitle: row.event?.title ?? '',

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -198,6 +198,131 @@ a { color: var(--primary); text-decoration: none; }
   border-radius: 999px;
   padding: 2px 8px;
 }
+
+/* ---- FDOT cut-off manager ---- */
+.cutoff-manager {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 32px 0 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.cutoff-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.cutoff-header h2 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.cutoff-header .helper {
+  margin: 6px 0 0;
+}
+
+.cutoff-header select {
+  margin-top: 8px;
+  min-width: 160px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--fg);
+}
+
+.warning {
+  background: color-mix(in srgb, var(--warning) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warning) 45%, transparent);
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 500;
+}
+
+.error-box {
+  background: color-mix(in srgb, var(--danger) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger) 45%, transparent);
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.error-box ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.cutoff-table-wrapper {
+  overflow-x: auto;
+  border-radius: 14px;
+  border: 1px solid var(--border-2);
+  background: var(--surface);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.28);
+}
+
+.cutoff-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+}
+
+.cutoff-table th,
+.cutoff-table td {
+  border-bottom: 1px solid var(--border-2);
+  padding: 12px 16px;
+  text-align: left;
+}
+
+.cutoff-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.cutoff-table input[type='date'],
+.cutoff-table input[type='text'] {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 80%, #000 20%);
+  color: var(--fg);
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.import-box {
+  border: 1px solid var(--border-2);
+  border-radius: 14px;
+  padding: 20px;
+  background: color-mix(in srgb, var(--surface) 92%, #000 8%);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.import-box textarea {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 80%, #000 20%);
+  color: var(--fg);
+  padding: 12px;
+  font-family: 'JetBrains Mono', 'Fira Mono', monospace;
+  min-height: 140px;
+}
+
+.import-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
 /* Header labels and more link */
 .fc .fc-col-header-cell-cushion { color: var(--muted); font-weight: 600; }
 .fc .fc-more-link { color: var(--muted) !important; font-weight: 500; }

--- a/src/components/CalendarWithData.tsx
+++ b/src/components/CalendarWithData.tsx
@@ -19,6 +19,7 @@ import UnassignedSidebar from '@/components/UnassignedSidebar';
 import EventQuantitiesEditor from '@/components/EventQuantitiesEditor';
 import { Toast } from '@/components/Toast';
 import PayItemsManager from '@/components/PayItemsManager';
+import { CutoffReportDialog } from '@/components/reports/CutoffReportDialog';
 import {
   Box,
   Button,
@@ -1167,6 +1168,7 @@ export default function CalendarWithData({ calendarId, initialYear, initialMonth
 
   const [todos, setTodos] = useState<Todo[]>([]);
   const [reportPickerOpen, setReportPickerOpen] = useState(false);
+  const [cutoffReportOpen, setCutoffReportOpen] = useState(false);
   const [reportDate, setReportDate] = useState<string>('');
   const [payItemsDialog, setPayItemsDialog] = useState(false);
   const reloadTodos = useCallback(async () => {
@@ -1465,6 +1467,7 @@ export default function CalendarWithData({ calendarId, initialYear, initialMonth
                 <button className="menu-row" role="menuitem" onClick={() => { setHolidayDialog(true); setOptsOpen(false); }}><span className="menu-ico">📅</span><span className="menu-text">Holidays</span></button>
                 <button className="menu-row" role="menuitem" onClick={() => { setWeatherDialog(true); setOptsOpen(false); }}><span className="menu-ico">⛅</span><span className="menu-text">Weather</span></button>
                 <button className="menu-row" role="menuitem" onClick={() => { setPayItemsDialog(true); setOptsOpen(false); }}><span className="menu-ico">📋</span><span className="menu-text">Pay Items</span></button>
+                <Link className="menu-row" role="menuitem" href="/admin/fdot-cutoffs" onClick={() => setOptsOpen(false)}><span className="menu-ico">🛣️</span><span className="menu-text">FDOT Cut-Off Dates</span></Link>
                 <Link className="menu-row" role="menuitem" href="/customers" onClick={() => setOptsOpen(false)}><span className="menu-ico">📂</span><span className="menu-text">Customers</span></Link>
                 <Suspense fallback={<span className="menu-row" aria-disabled>Employees</span>}><EmployeesLink /></Suspense>
               </div>
@@ -1492,6 +1495,7 @@ export default function CalendarWithData({ calendarId, initialYear, initialMonth
                 <button className="menu-item" role="menuitem" onClick={() => { setHolidayDialog(true); setOptsOpen(false); }}>Holidays…</button>
                 <button className="menu-item" role="menuitem" onClick={() => { setWeatherDialog(true); setOptsOpen(false); }}>Weather…</button>
                 <button className="menu-item" role="menuitem" onClick={() => { setPayItemsDialog(true); setOptsOpen(false); }}>Pay Items…</button>
+                <a className="menu-item" role="menuitem" href="/admin/fdot-cutoffs" onClick={() => setOptsOpen(false)}>FDOT Cut-Off Dates…</a>
                 <a className="menu-item" role="menuitem" href="/customers" onClick={() => setOptsOpen(false)}>Customers</a>
                 <Suspense fallback={<span className="menu-item" aria-disabled>Employees</span>}>
                   <EmployeesLink />
@@ -1512,6 +1516,7 @@ export default function CalendarWithData({ calendarId, initialYear, initialMonth
             setReportDate(`${y}-${m}-${d}`);
             setReportPickerOpen(true);
           }}>Generate Daily Report</button>
+          <button className="btn" onClick={() => setCutoffReportOpen(true)}>Generate Cut-Off Report</button>
         </div>
       </div>
 
@@ -1730,6 +1735,8 @@ export default function CalendarWithData({ calendarId, initialYear, initialMonth
           </div>
         </div>
       ) : null}
+
+      <CutoffReportDialog open={cutoffReportOpen} onClose={() => setCutoffReportOpen(false)} />
 
       {draft ? (
         <Dialog

--- a/src/components/admin/FdotCutoffManager.tsx
+++ b/src/components/admin/FdotCutoffManager.tsx
@@ -1,0 +1,414 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Toast } from '@/components/Toast'
+
+type CutoffRow = {
+  id: string | null
+  cutoffDate: string
+  label: string
+  tempId: string
+}
+
+type ApiCutoff = {
+  id: string
+  cutoffDate: string
+  label: string | null
+}
+
+type ApiResponse = {
+  years: number[]
+  cutoffs: Record<string, ApiCutoff[]>
+}
+
+function normalizeRows(rows: CutoffRow[]): ApiCutoff[] {
+  return rows
+    .map(row => ({
+      id: row.id ?? '',
+      cutoffDate: row.cutoffDate.trim(),
+      label: row.label.trim() || null,
+    }))
+    .filter(row => row.cutoffDate)
+}
+
+function makeTempId(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID()
+  return `tmp-${Math.random().toString(36).slice(2)}-${Date.now()}`
+}
+
+function parseImport(text: string, expectedYear: number): { rows: CutoffRow[]; errors: string[] } {
+  const rows: CutoffRow[] = []
+  const errors: string[] = []
+  const lines = text
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+  if (!lines.length) return { rows, errors }
+
+  lines.forEach((line, index) => {
+    const [datePart, ...rest] = line.split(',')
+    const cutoffDate = (datePart || '').trim()
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(cutoffDate)) {
+      errors.push(`Row ${index + 1}: invalid cutoff_date "${cutoffDate}"`)
+      return
+    }
+    const [year] = cutoffDate.split('-').map(Number)
+    if (year !== expectedYear) {
+      errors.push(`Row ${index + 1}: year ${year} does not match ${expectedYear}`)
+      return
+    }
+    const label = rest.join(',').trim()
+    rows.push({ id: null, cutoffDate, label, tempId: makeTempId() })
+  })
+
+  const seen = new Set<string>()
+  for (const row of rows) {
+    if (seen.has(row.cutoffDate)) {
+      errors.push(`Duplicate cutoff date ${row.cutoffDate}`)
+    }
+    seen.add(row.cutoffDate)
+  }
+
+  rows.sort((a, b) => a.cutoffDate.localeCompare(b.cutoffDate))
+  return { rows, errors }
+}
+
+function validateRows(rows: CutoffRow[], year: number): string[] {
+  const errors: string[] = []
+  const seen = new Set<string>()
+  rows.forEach((row, idx) => {
+    if (!row.cutoffDate) {
+      errors.push(`Row ${idx + 1}: cutoff date required`)
+      return
+    }
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(row.cutoffDate)) {
+      errors.push(`Row ${idx + 1}: invalid cutoff date format`)
+      return
+    }
+    const [y] = row.cutoffDate.split('-').map(Number)
+    if (y !== year) {
+      errors.push(`Row ${idx + 1}: cutoff date must be in ${year}`)
+    }
+    if (seen.has(row.cutoffDate)) {
+      errors.push(`Row ${idx + 1}: duplicate cutoff date ${row.cutoffDate}`)
+    }
+    seen.add(row.cutoffDate)
+  })
+
+  return errors
+}
+
+export default function FdotCutoffManager() {
+  const [years, setYears] = useState<number[]>([])
+  const [selectedYear, setSelectedYear] = useState<number | null>(null)
+  const [rows, setRows] = useState<CutoffRow[]>([])
+  const originalsRef = useRef<Record<number, ApiCutoff[]>>({})
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [errors, setErrors] = useState<string[]>([])
+  const [csvText, setCsvText] = useState('')
+  const [toast, setToast] = useState<{ open: boolean; message: string }>({ open: false, message: '' })
+  const [dirty, setDirty] = useState(false)
+
+  const showToast = useCallback((message: string) => setToast({ open: true, message }), [])
+  const closeToast = useCallback(() => setToast({ open: false, message: '' }), [])
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true)
+      try {
+        const res = await fetch('/api/fdot-cutoffs', { cache: 'no-store' })
+        if (!res.ok) throw new Error('Failed to load cut-offs')
+        const json = (await res.json()) as Partial<ApiResponse>
+        const yearsList = Array.isArray(json.years) ? [...new Set(json.years.map(Number))].sort((a, b) => a - b) : []
+        const grouped: Record<number, ApiCutoff[]> = {}
+        if (json.cutoffs && typeof json.cutoffs === 'object') {
+          Object.entries(json.cutoffs).forEach(([key, value]) => {
+            const yr = Number(key)
+            if (!Number.isFinite(yr)) return
+            const arr = Array.isArray(value)
+              ? value.map(item => ({
+                  id: item.id ?? '',
+                  cutoffDate: (item.cutoffDate ?? '').slice(0, 10),
+                  label: item.label ?? null,
+                }))
+              : []
+            grouped[yr] = arr
+          })
+        }
+        originalsRef.current = grouped
+        setYears(yearsList.length ? yearsList : [])
+        const defaultYear = yearsList.includes(new Date().getUTCFullYear())
+          ? new Date().getUTCFullYear()
+          : yearsList[yearsList.length - 1] ?? null
+        setSelectedYear(defaultYear)
+        if (defaultYear != null) {
+          const base = grouped[defaultYear] ?? []
+          setRows(base.map(item => ({
+            id: item.id || null,
+            cutoffDate: item.cutoffDate,
+            label: item.label ?? '',
+            tempId: makeTempId(),
+          })))
+        } else {
+          setRows([])
+        }
+        setDirty(false)
+      } catch (err) {
+        console.error(err)
+        showToast('Failed to load FDOT cut-off dates')
+      } finally {
+        setLoading(false)
+      }
+    }
+    void load()
+  }, [showToast])
+
+  const onSelectYear = useCallback((value: string) => {
+    if (value === 'add') {
+      const input = window.prompt('Enter year (e.g., 2025)')
+      if (!input) return
+      const year = Number.parseInt(input, 10)
+      if (!Number.isFinite(year) || year < 2000 || year > 2100) {
+        showToast('Invalid year')
+        return
+      }
+      setYears(prev => {
+        const set = new Set(prev)
+        set.add(year)
+        return Array.from(set).sort((a, b) => a - b)
+      })
+      const existing = originalsRef.current[year] ?? []
+      setRows(existing.map(item => ({
+        id: item.id || null,
+        cutoffDate: item.cutoffDate,
+        label: item.label ?? '',
+        tempId: makeTempId(),
+      })))
+      setSelectedYear(year)
+      setDirty(false)
+      setErrors([])
+      return
+    }
+    const year = Number.parseInt(value, 10)
+    if (!Number.isFinite(year)) return
+    setSelectedYear(year)
+    const existing = originalsRef.current[year] ?? []
+    setRows(existing.map(item => ({
+      id: item.id || null,
+      cutoffDate: item.cutoffDate,
+      label: item.label ?? '',
+      tempId: makeTempId(),
+    })))
+    setDirty(false)
+    setErrors([])
+  }, [showToast])
+
+  const addRow = useCallback(() => {
+    setRows(prev => [...prev, { id: null, cutoffDate: '', label: '', tempId: makeTempId() }])
+    setDirty(true)
+  }, [])
+
+  const updateRow = useCallback((tempId: string, field: 'cutoffDate' | 'label', value: string) => {
+    setRows(prev => prev.map(row => (row.tempId === tempId ? { ...row, [field]: value } : row)))
+    setDirty(true)
+  }, [])
+
+  const deleteRow = useCallback((tempId: string) => {
+    setRows(prev => prev.filter(row => row.tempId !== tempId))
+    setDirty(true)
+  }, [])
+
+  const applyImport = useCallback(() => {
+    if (selectedYear == null) return
+    const { rows: parsed, errors: errs } = parseImport(csvText, selectedYear)
+    if (errs.length) {
+      setErrors(errs)
+      return
+    }
+    setRows(parsed)
+    setDirty(true)
+    setErrors([])
+  }, [csvText, selectedYear])
+
+  const sortedRows = useMemo(() => {
+    return [...rows].sort((a, b) => a.cutoffDate.localeCompare(b.cutoffDate))
+  }, [rows])
+
+  const handleSave = useCallback(async () => {
+    if (selectedYear == null) return
+    const validationErrors = validateRows(sortedRows, selectedYear)
+    if (validationErrors.length) {
+      setErrors(validationErrors)
+      return
+    }
+    setErrors([])
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/fdot-cutoffs/${selectedYear}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cutoffs: normalizeRows(sortedRows) }),
+      })
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        showToast(json.error || 'Failed to save cut-offs')
+        return
+      }
+      const savedApi: ApiCutoff[] = Array.isArray(json.cutoffs)
+        ? json.cutoffs.map((item: ApiCutoff) => ({
+            id: item.id ?? '',
+            cutoffDate: (item.cutoffDate ?? '').slice(0, 10),
+            label: item.label ?? null,
+          }))
+        : []
+      originalsRef.current[selectedYear] = savedApi
+      setRows(
+        savedApi.map(item => ({
+          id: item.id || null,
+          cutoffDate: item.cutoffDate,
+          label: item.label ?? '',
+          tempId: makeTempId(),
+        })),
+      )
+      setDirty(false)
+      showToast('Cut-off dates saved')
+    } catch (err) {
+      console.error(err)
+      showToast('Failed to save cut-offs')
+    } finally {
+      setSaving(false)
+    }
+  }, [selectedYear, showToast, sortedRows])
+
+  const unsavedWarning = dirty ? 'You have unsaved changes' : ''
+
+  return (
+    <div className="cutoff-manager">
+      <Toast open={toast.open} message={toast.message} onClose={closeToast} />
+      <div className="cutoff-header">
+        <div>
+          <h2>FDOT Cut-Off Dates</h2>
+          <p className="helper">Manage FDOT cut-off Sundays per year.</p>
+        </div>
+        <div className="year-select">
+          <label>
+            Year
+            <select
+              value={selectedYear ?? ''}
+              onChange={e => onSelectYear(e.target.value)}
+              disabled={loading}
+            >
+              <option value="" disabled>
+                Select year
+              </option>
+              {years.map(year => (
+                <option key={year} value={year}>
+                  {year}
+                </option>
+              ))}
+              <option value="add">➕ Add Year…</option>
+            </select>
+          </label>
+        </div>
+      </div>
+
+      {unsavedWarning ? <div className="warning">{unsavedWarning}</div> : null}
+      {errors.length ? (
+        <div className="error-box">
+          <ul>
+            {errors.map((err, idx) => (
+              <li key={idx}>{err}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="cutoff-table-wrapper">
+        <table className="cutoff-table">
+          <thead>
+            <tr>
+              <th style={{ width: '180px' }}>Cut-Off Date</th>
+              <th>Label</th>
+              <th style={{ width: '80px' }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedRows.length ? (
+              sortedRows.map(row => (
+                <tr key={row.tempId}>
+                  <td>
+                    <input
+                      type="date"
+                      value={row.cutoffDate}
+                      onChange={e => updateRow(row.tempId, 'cutoffDate', e.target.value)}
+                      disabled={loading}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="text"
+                      value={row.label}
+                      placeholder="e.g., 2nd Sunday"
+                      onChange={e => updateRow(row.tempId, 'label', e.target.value)}
+                      disabled={loading}
+                    />
+                  </td>
+                  <td>
+                    <button
+                      type="button"
+                      className="btn ghost"
+                      onClick={() => deleteRow(row.tempId)}
+                      disabled={loading}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan={3} style={{ textAlign: 'center', color: '#666', padding: '1rem' }}>
+                  {selectedYear == null ? 'Select a year to begin' : 'No cut-off dates yet'}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="actions">
+        <button type="button" className="btn ghost" onClick={addRow} disabled={selectedYear == null || loading}>
+          Add Row
+        </button>
+        <button type="button" className="btn primary" onClick={handleSave} disabled={saving || selectedYear == null}>
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+
+      <section className="import-box">
+        <h3>Bulk Import</h3>
+        <p className="helper">Paste CSV rows with columns: cutoff_date,label</p>
+        <textarea
+          value={csvText}
+          onChange={e => setCsvText(e.target.value)}
+          placeholder={`2025-01-19,\n2025-02-16,\n2025-03-16,\n2025-04-13,2nd Sunday …`}
+          rows={6}
+        />
+        <div className="import-actions">
+          <button
+            type="button"
+            className="btn primary"
+            onClick={applyImport}
+            disabled={selectedYear == null || !csvText.trim()}
+          >
+            Replace with CSV
+          </button>
+          <button type="button" className="btn ghost" onClick={() => setCsvText('')}>
+            Clear
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/reports/CutoffReportDialog.tsx
+++ b/src/components/reports/CutoffReportDialog.tsx
@@ -1,0 +1,548 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Toast } from '@/components/Toast'
+
+const START_OF_YEAR = '__start_of_year__'
+const PAGE_SIZE = 1000
+
+export type Cutoff = {
+  id: string
+  cutoffDate: string
+  label: string | null
+  year: number
+}
+
+export type PreviewRow = {
+  jobId: string
+  jobName: string
+  payItem: string
+  description: string
+  unit: string
+  quantity: number
+  firstWorkDate: string
+  lastWorkDate: string
+}
+
+type JobTotal = {
+  jobId: string
+  jobName: string
+  quantity: number
+}
+
+type WindowInfo = {
+  startDate: string
+  endDate: string
+  toCutoff: Cutoff
+  previousCutoff: Cutoff | null
+}
+
+type PreviewResponse = {
+  window: WindowInfo
+  rows: PreviewRow[]
+  totalRows: number
+  page: number
+  pageSize: number
+  jobTotals: JobTotal[]
+  grandTotal: number
+}
+
+type Props = {
+  open: boolean
+  onClose: () => void
+}
+
+function numberFmt(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+function formatCutoffOption(cutoff: Cutoff): string {
+  return cutoff.label ? `${cutoff.cutoffDate} (${cutoff.label})` : cutoff.cutoffDate
+}
+
+function addDays(ymd: string, days: number): string {
+  const date = new Date(`${ymd}T00:00:00Z`)
+  date.setUTCDate(date.getUTCDate() + days)
+  return date.toISOString().slice(0, 10)
+}
+
+export function CutoffReportDialog({ open, onClose }: Props) {
+  const [loading, setLoading] = useState(false)
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const [exporting, setExporting] = useState(false)
+  const [years, setYears] = useState<number[]>([])
+  const [cutoffsByYear, setCutoffsByYear] = useState<Record<number, Cutoff[]>>({})
+  const [selectedYear, setSelectedYear] = useState<number | null>(null)
+  const [fromId, setFromId] = useState<string>('')
+  const [toId, setToId] = useState<string>('')
+  const [preview, setPreview] = useState<PreviewResponse | null>(null)
+  const [toast, setToast] = useState<{ open: boolean; message: string }>({ open: false, message: '' })
+  const [page, setPage] = useState(1)
+
+  const showToast = useCallback((message: string) => setToast({ open: true, message }), [])
+  const closeToast = useCallback(() => setToast({ open: false, message: '' }), [])
+
+  const loadCutoffs = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/fdot-cutoffs', { cache: 'no-store' })
+      if (!res.ok) throw new Error('Failed to load cut-offs')
+      const json = await res.json()
+      const yearsList: number[] = Array.isArray(json.years)
+        ? [...new Set(json.years.map((y: any) => Number(y)))].filter(Number.isFinite).sort((a, b) => a - b)
+        : []
+      const grouped: Record<number, Cutoff[]> = {}
+      if (json.cutoffs && typeof json.cutoffs === 'object') {
+        Object.entries(json.cutoffs).forEach(([key, value]) => {
+          const year = Number(key)
+          if (!Number.isFinite(year)) return
+          const list: Cutoff[] = Array.isArray(value)
+            ? value.map((item: any) => ({
+                id: String(item.id ?? ''),
+                cutoffDate: String(item.cutoffDate ?? '').slice(0, 10),
+                label: item.label != null ? String(item.label) : null,
+                year,
+              }))
+            : []
+          grouped[year] = list.sort((a, b) => a.cutoffDate.localeCompare(b.cutoffDate))
+        })
+      }
+      setYears(yearsList)
+      setCutoffsByYear(grouped)
+      const currentYear = new Date().getFullYear()
+      const defaultYear = yearsList.includes(currentYear)
+        ? currentYear
+        : yearsList[yearsList.length - 1] ?? null
+      setSelectedYear(prev => {
+        if (prev != null && yearsList.includes(prev)) return prev
+        return defaultYear ?? null
+      })
+    } catch (err) {
+      console.error(err)
+      showToast('Failed to load cut-off dates')
+    } finally {
+      setLoading(false)
+    }
+  }, [showToast])
+
+  useEffect(() => {
+    if (open) {
+      void loadCutoffs()
+    }
+  }, [open, loadCutoffs])
+
+  useEffect(() => {
+    if (!open) return
+    setPreview(null)
+    setPage(1)
+  }, [open, selectedYear, fromId, toId])
+
+  const currentCutoffs = useMemo(() => {
+    if (selectedYear == null) return []
+    return cutoffsByYear[selectedYear] ?? []
+  }, [cutoffsByYear, selectedYear])
+
+  // Establish defaults when year changes
+  useEffect(() => {
+    if (selectedYear == null) {
+      setFromId('')
+      setToId('')
+      return
+    }
+    const list = cutoffsByYear[selectedYear] ?? []
+    if (!list.length) {
+      setFromId('')
+      setToId('')
+      return
+    }
+    const today = new Date().toISOString().slice(0, 10)
+    let toIndex = list.findIndex(c => c.cutoffDate >= today)
+    if (toIndex === -1) toIndex = list.length - 1
+    if (toIndex <= 0) {
+      // Either first cut-off of the year or before the first cut-off
+      setFromId(START_OF_YEAR)
+      setToId(list[0]!.id)
+    } else {
+      setFromId(list[toIndex - 1]!.id)
+      setToId(list[toIndex]!.id)
+    }
+  }, [selectedYear, cutoffsByYear])
+
+  useEffect(() => {
+    if (selectedYear == null) return
+    const list = cutoffsByYear[selectedYear] ?? []
+    if (!list.length) {
+      setToId('')
+      return
+    }
+    let next: Cutoff | null = null
+    if (fromId === START_OF_YEAR) {
+      next = list[0] ?? null
+    } else if (fromId) {
+      const idx = list.findIndex(c => c.id === fromId)
+      if (idx >= 0 && idx + 1 < list.length) next = list[idx + 1] ?? null
+    }
+    setToId(next?.id ?? '')
+  }, [fromId, selectedYear, cutoffsByYear])
+
+  const fromOptions = useMemo(() => {
+    if (selectedYear == null) return []
+    const list = cutoffsByYear[selectedYear] ?? []
+    const opts = list
+      .slice(0, Math.max(0, list.length - 1))
+      .map(cutoff => ({ id: cutoff.id, label: formatCutoffOption(cutoff), cutoff }))
+    if (list.length) {
+      opts.unshift({
+        id: START_OF_YEAR,
+        label: `Start of ${selectedYear} (Jan 1)`,
+        cutoff: {
+          id: START_OF_YEAR,
+          cutoffDate: `${selectedYear}-01-01`,
+          label: null,
+          year: selectedYear,
+        } as Cutoff,
+      })
+    }
+    return opts
+  }, [cutoffsByYear, selectedYear])
+
+  const toCutoff = useMemo(() => {
+    if (selectedYear == null || !toId) return null
+    const list = cutoffsByYear[selectedYear] ?? []
+    return list.find(c => c.id === toId) ?? null
+  }, [cutoffsByYear, selectedYear, toId])
+
+  const previousCutoff = useMemo(() => {
+    if (selectedYear == null) return null
+    const list = cutoffsByYear[selectedYear] ?? []
+    if (fromId && fromId !== START_OF_YEAR) {
+      return list.find(c => c.id === fromId) ?? null
+    }
+    const toIndex = toCutoff ? list.findIndex(c => c.id === toCutoff.id) : -1
+    if (toIndex > 0) {
+      return list[toIndex - 1] ?? null
+    }
+    const prior = cutoffsByYear[selectedYear - 1] ?? []
+    return prior.length ? prior[prior.length - 1]! : null
+  }, [cutoffsByYear, selectedYear, fromId, toCutoff])
+
+  const computedWindow = useMemo<WindowInfo | null>(() => {
+    if (!selectedYear || !toCutoff) return null
+    const startDate = previousCutoff ? addDays(previousCutoff.cutoffDate, 1) : `${selectedYear}-01-01`
+    return {
+      startDate,
+      endDate: toCutoff.cutoffDate,
+      toCutoff,
+      previousCutoff: previousCutoff ?? null,
+    }
+  }, [selectedYear, toCutoff, previousCutoff])
+
+  const canSubmit = !!selectedYear && !!toCutoff
+
+  const displayWindow = preview?.window ?? computedWindow
+
+  const handlePreview = useCallback(async (pageOverride?: number) => {
+    if (!canSubmit) return
+    const pageToLoad = pageOverride ?? 1
+    setPreviewLoading(true)
+    try {
+      const res = await fetch('/api/reports/fdot-cutoff', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          year: selectedYear,
+          toCutoff: toCutoff?.id,
+          page: pageToLoad,
+          pageSize: PAGE_SIZE,
+        }),
+      })
+      const json = await res.json().catch(() => null)
+      if (!res.ok || !json) {
+        throw new Error(json?.error || 'Failed to generate report')
+      }
+      const normalized: PreviewResponse = {
+        window: {
+          startDate: String(json.window?.startDate ?? ''),
+          endDate: String(json.window?.endDate ?? ''),
+          toCutoff: {
+            id: String(json.window?.toCutoff?.id ?? toCutoff?.id ?? ''),
+            cutoffDate: String(json.window?.toCutoff?.cutoffDate ?? toCutoff?.cutoffDate ?? '').slice(0, 10),
+            label: json.window?.toCutoff?.label ?? (toCutoff?.label ?? null),
+            year: Number(json.window?.toCutoff?.year ?? selectedYear ?? 0),
+          },
+          previousCutoff: json.window?.previousCutoff
+            ? {
+                id: String(json.window.previousCutoff.id ?? ''),
+                cutoffDate: String(json.window.previousCutoff.cutoffDate ?? '').slice(0, 10),
+                label: json.window.previousCutoff.label ?? null,
+                year: Number(json.window.previousCutoff.year ?? (selectedYear ?? 0)),
+              }
+            : null,
+        },
+        rows: Array.isArray(json.rows)
+          ? json.rows.map((row: any) => ({
+              jobId: String(row.jobId ?? ''),
+              jobName: String(row.jobName ?? ''),
+              payItem: String(row.payItem ?? ''),
+              description: row.description != null ? String(row.description) : '',
+              unit: row.unit != null ? String(row.unit) : '',
+              quantity: Number(row.quantity ?? 0),
+              firstWorkDate: String(row.firstWorkDate ?? '').slice(0, 10),
+              lastWorkDate: String(row.lastWorkDate ?? '').slice(0, 10),
+            }))
+          : [],
+        totalRows: Number(json.totalRows ?? 0),
+        page: Number(json.page ?? pageToLoad),
+        pageSize: Number(json.pageSize ?? PAGE_SIZE),
+        jobTotals: Array.isArray(json.jobTotals)
+          ? json.jobTotals.map((jt: any) => ({
+              jobId: String(jt.jobId ?? ''),
+              jobName: String(jt.jobName ?? ''),
+              quantity: Number(jt.quantity ?? 0),
+            }))
+          : [],
+        grandTotal: Number(json.grandTotal ?? 0),
+      }
+      setPreview(normalized)
+      setPage(normalized.page)
+    } catch (err) {
+      console.error(err)
+      showToast(err instanceof Error ? err.message : 'Failed to generate report')
+    } finally {
+      setPreviewLoading(false)
+    }
+  }, [canSubmit, selectedYear, toCutoff, showToast])
+
+  const handleExport = useCallback(async () => {
+    if (!canSubmit) return
+    setExporting(true)
+    try {
+      const res = await fetch('/api/reports/fdot-cutoff', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          year: selectedYear,
+          toCutoff: toCutoff?.id,
+          format: 'csv',
+        }),
+      })
+      if (!res.ok) {
+        const json = await res.json().catch(() => null)
+        throw new Error(json?.error || 'Failed to export CSV')
+      }
+      const blob = await res.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      const endDate = computedWindow?.endDate ?? (toCutoff?.cutoffDate ?? '')
+      a.download = endDate ? `fdot-cutoff-${endDate}.csv` : 'fdot-cutoff.csv'
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+      showToast('CSV export ready')
+    } catch (err) {
+      console.error(err)
+      showToast(err instanceof Error ? err.message : 'Failed to export CSV')
+    } finally {
+      setExporting(false)
+    }
+  }, [canSubmit, selectedYear, toCutoff, computedWindow, showToast])
+
+  const handleClose = useCallback(() => {
+    setPreview(null)
+    setPage(1)
+    onClose()
+  }, [onClose])
+
+  const totalRows = preview?.totalRows ?? 0
+  const pageSize = preview?.pageSize ?? PAGE_SIZE
+  const currentPage = preview?.page ?? page
+  const pageStart = totalRows ? (currentPage - 1) * pageSize + 1 : 0
+  const pageEnd = totalRows ? Math.min(currentPage * pageSize, totalRows) : 0
+  const hasPrevPage = currentPage > 1
+  const hasNextPage = totalRows > pageEnd
+
+  if (!open) return null
+
+  return (
+    <div className="modal-root" onClick={e => { if (e.currentTarget === e.target) handleClose() }}>
+      <Toast open={toast.open} message={toast.message} onClose={closeToast} />
+      <div className="modal-card" style={{ width: 'min(960px, 94vw)', maxHeight: '90vh', overflowY: 'auto' }}>
+        <div className="modal-title" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span>Generate Cut-Off Report</span>
+          <button className="icon-btn" aria-label="Close" onClick={handleClose}>
+            ✕
+          </button>
+        </div>
+        <div className="form-grid" style={{ gap: '16px' }}>
+          <div className="row">
+            <div className="col">
+              <label>
+                <div className="label">Year</div>
+                <select
+                  value={selectedYear ?? ''}
+                  onChange={e => {
+                    const value = Number(e.target.value)
+                    setSelectedYear(Number.isFinite(value) ? value : null)
+                    setPreview(null)
+                  }}
+                  disabled={loading || !years.length}
+                >
+                  <option value="" disabled>
+                    Select year
+                  </option>
+                  {years.map(year => (
+                    <option key={year} value={year}>
+                      {year}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <div className="col">
+              <label>
+                <div className="label">From Cut-Off</div>
+                <select
+                  value={fromId}
+                  onChange={e => setFromId(e.target.value)}
+                  disabled={loading || !fromOptions.length}
+                >
+                  {!fromOptions.length ? (
+                    <option value="">No cut-offs available</option>
+                  ) : null}
+                  {fromOptions.map(option => (
+                    <option key={option.id} value={option.id}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <div className="col">
+              <label>
+                <div className="label">To Cut-Off</div>
+                <select value={toId} disabled>
+                  <option value={toId || ''}>{toCutoff ? formatCutoffOption(toCutoff) : 'Select From Cut-Off'}</option>
+                </select>
+              </label>
+            </div>
+          </div>
+          <div>
+            <div className="label">Report Window</div>
+            {displayWindow ? (
+              <div className="muted-sm">
+                Report window = previous cut-off + 1 day through selected cut-off (inclusive).
+                <br />
+                {displayWindow.previousCutoff
+                  ? `Previous Cut-Off: ${displayWindow.previousCutoff.cutoffDate}`
+                  : `Previous Cut-Off: none (using Jan 1 ${selectedYear})`}
+                <br />
+                {`Start Date: ${displayWindow.startDate}`} → {`End Date: ${displayWindow.endDate}`}
+              </div>
+            ) : (
+              <div className="muted-sm">Select a year and cut-off pair to view the reporting window.</div>
+            )}
+          </div>
+        </div>
+        <div className="modal-actions" style={{ justifyContent: 'flex-start', gap: '12px', marginTop: '20px' }}>
+          <button className="btn ghost" onClick={handleClose}>
+            Cancel
+          </button>
+          <button className="btn primary" onClick={() => handlePreview(1)} disabled={!canSubmit || previewLoading}>
+            {previewLoading ? 'Loading…' : 'Preview'}
+          </button>
+          <button className="btn" onClick={handleExport} disabled={!canSubmit || exporting}>
+            {exporting ? 'Exporting…' : 'Export CSV'}
+          </button>
+        </div>
+        {preview ? (
+          <div style={{ marginTop: '24px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: '12px' }}>
+              <div>
+                <strong>
+                  {`Showing ${pageStart}-${pageEnd} of ${totalRows} line items`}
+                </strong>
+                <div className="muted-sm">
+                  Grand Total Quantity: {numberFmt(preview.grandTotal)}
+                </div>
+              </div>
+              <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                <button
+                  className="btn ghost"
+                  onClick={() => handlePreview(currentPage - 1)}
+                  disabled={!hasPrevPage || previewLoading}
+                >
+                  ← Prev
+                </button>
+                <span className="muted-sm">Page {currentPage}</span>
+                <button
+                  className="btn ghost"
+                  onClick={() => handlePreview(currentPage + 1)}
+                  disabled={!hasNextPage || previewLoading}
+                >
+                  Next →
+                </button>
+              </div>
+            </div>
+            <div className="cutoff-table-wrapper">
+              <table className="cutoff-table">
+                <thead>
+                  <tr>
+                    <th>Job Name</th>
+                    <th>Job ID</th>
+                    <th>Pay Item</th>
+                    <th>Description</th>
+                    <th>Unit</th>
+                    <th style={{ textAlign: 'right' }}>Quantity</th>
+                    <th>First Work Date</th>
+                    <th>Last Work Date</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.rows.length ? (
+                    preview.rows.map((row, idx) => (
+                      <tr key={`${row.jobId}-${row.payItem}-${idx}`}>
+                        <td>{row.jobName || '—'}</td>
+                        <td>{row.jobId || '—'}</td>
+                        <td>{row.payItem || '—'}</td>
+                        <td>{row.description || '—'}</td>
+                        <td>{row.unit || '—'}</td>
+                        <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>{numberFmt(row.quantity)}</td>
+                        <td>{row.firstWorkDate || '—'}</td>
+                        <td>{row.lastWorkDate || '—'}</td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan={8} style={{ textAlign: 'center', padding: '18px 12px', color: 'var(--muted)' }}>
+                        No FDOT quantities found for this window.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+            {preview.jobTotals.length ? (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                <h4 style={{ margin: '0 0 4px' }}>Totals by Job</h4>
+                <div style={{ display: 'grid', gap: '6px', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+                  {preview.jobTotals.map(total => (
+                    <div key={total.jobId || total.jobName} className="surface" style={{ padding: '12px', borderRadius: '12px', border: '1px solid var(--border-2)' }}>
+                      <div style={{ fontWeight: 600 }}>{total.jobName || 'Unnamed Job'}</div>
+                      <div className="muted-sm">ID: {total.jobId || '—'}</div>
+                      <div style={{ marginTop: '6px' }}>Quantity: {numberFmt(total.quantity)}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/server/fdotCutoffs.ts
+++ b/src/server/fdotCutoffs.ts
@@ -1,0 +1,417 @@
+// src/server/fdotCutoffs.ts
+import { Prisma } from '@prisma/client'
+import { getPrisma } from '@/lib/db'
+import { tryPrisma } from '@/lib/dbSafe'
+
+export type FdotCutoffRecord = {
+  id: string
+  year: number
+  cutoffDate: string
+  label: string | null
+  createdBy: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type CutoffInputRow = {
+  id?: string | null
+  cutoffDate: string
+  label?: string | null
+}
+
+export type CutoffWindow = {
+  year: number
+  startDate: string
+  endDate: string
+  startDateUtc: Date
+  endDateUtc: Date
+  toCutoff: FdotCutoffRecord
+  previousCutoff: FdotCutoffRecord | null
+}
+
+function normalizeYmd(input: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(input)) {
+    throw new Error('Invalid cutoff_date format; expected YYYY-MM-DD')
+  }
+  return input
+}
+
+function toUtcDate(ymd: string): Date {
+  const [y, m, d] = ymd.split('-').map(n => Number.parseInt(n, 10))
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
+    throw new Error('Invalid cutoff_date components')
+  }
+  return new Date(Date.UTC(y, m - 1, d))
+}
+
+function ensureSameYear(expected: number, ymd: string) {
+  const [y] = ymd.split('-').map(n => Number.parseInt(n, 10))
+  if (y !== expected) {
+    throw new Error('All cutoff dates must belong to the selected year')
+  }
+}
+
+function toPayload(row: any): FdotCutoffRecord {
+  return {
+    id: String(row.id ?? ''),
+    year: Number(row.year ?? 0),
+    cutoffDate: new Date(row.cutoffDate ?? Date.now()).toISOString().slice(0, 10),
+    label: row.label ? String(row.label) : null,
+    createdBy: row.createdBy ? String(row.createdBy) : null,
+    createdAt: new Date(row.createdAt ?? Date.now()).toISOString(),
+    updatedAt: new Date(row.updatedAt ?? Date.now()).toISOString(),
+  }
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date.getTime())
+  next.setUTCDate(next.getUTCDate() + days)
+  return next
+}
+
+function ymd(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+export async function fetchCutoffYears(): Promise<number[]> {
+  const rows = await tryPrisma(
+    p =>
+      p.fdotCutoff.findMany({
+        select: { year: true },
+        distinct: ['year'],
+        orderBy: { year: 'asc' },
+      }),
+    [] as Array<{ year: number }>,
+  )
+  return rows.map(row => row.year).sort((a, b) => a - b)
+}
+
+export async function fetchCutoffsForYear(year: number): Promise<FdotCutoffRecord[]> {
+  if (!Number.isFinite(year)) return []
+  const rows = await tryPrisma(
+    p =>
+      p.fdotCutoff.findMany({
+        where: { year },
+        orderBy: { cutoffDate: 'asc' },
+      }),
+    [] as any[],
+  )
+  return rows.map(toPayload)
+}
+
+export async function fetchAllCutoffs(): Promise<Record<string, FdotCutoffRecord[]>> {
+  const rows = await tryPrisma(
+    p => p.fdotCutoff.findMany({ orderBy: [{ year: 'asc' }, { cutoffDate: 'asc' }] }),
+    [] as any[],
+  )
+  const grouped = new Map<number, FdotCutoffRecord[]>()
+  rows.forEach(row => {
+    const payload = toPayload(row)
+    if (!grouped.has(payload.year)) grouped.set(payload.year, [])
+    grouped.get(payload.year)!.push(payload)
+  })
+  const out: Record<string, FdotCutoffRecord[]> = {}
+  Array.from(grouped.entries())
+    .sort((a, b) => a[0] - b[0])
+    .forEach(([yr, list]) => {
+      out[String(yr)] = list
+    })
+  return out
+}
+
+export type SaveResult = {
+  created: number
+  updated: number
+  deleted: number
+  records: FdotCutoffRecord[]
+}
+
+export async function saveCutoffs(
+  year: number,
+  rows: CutoffInputRow[],
+  userId: string | null,
+): Promise<SaveResult> {
+  if (!Number.isFinite(year)) {
+    throw Object.assign(new Error('year is required'), { status: 400 })
+  }
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return { created: 0, updated: 0, deleted: 0, records: [] }
+  }
+
+  const seenDates = new Set<string>()
+  const normalizedRows = rows.map(row => {
+    const ymdValue = normalizeYmd(String(row.cutoffDate ?? '').trim())
+    ensureSameYear(year, ymdValue)
+    if (seenDates.has(ymdValue)) {
+      throw Object.assign(new Error(`Duplicate cutoff date: ${ymdValue}`), { status: 400 })
+    }
+    seenDates.add(ymdValue)
+    return {
+      id: row.id ? String(row.id) : null,
+      cutoffDate: ymdValue,
+      label: row.label ? String(row.label).trim() || null : null,
+    }
+  })
+
+  const sorted = [...normalizedRows].sort((a, b) => (a.cutoffDate < b.cutoffDate ? -1 : a.cutoffDate > b.cutoffDate ? 1 : 0))
+  for (let i = 0; i < sorted.length; i++) {
+    if (sorted[i]!.cutoffDate !== normalizedRows[i]!.cutoffDate) {
+      // Input not sorted, but we sort server-side as well. No-op.
+    }
+  }
+
+  const prisma = await getPrisma()
+  const existing = await prisma.fdotCutoff.findMany({ where: { year } })
+  const existingById = new Map(existing.map(row => [String(row.id), row]))
+  const keepIds = new Set(sorted.map(row => (row.id ? row.id : '').trim()).filter(Boolean))
+  const toDelete = existing.filter(row => !keepIds.has(String(row.id))).map(row => String(row.id))
+
+  let created = 0
+  let updated = 0
+
+  const results = await prisma.$transaction(async tx => {
+    if (toDelete.length > 0) {
+      await tx.fdotCutoff.deleteMany({ where: { id: { in: toDelete } } })
+    }
+
+    const persisted: any[] = []
+    for (const row of sorted) {
+      const data = {
+        year,
+        cutoffDate: toUtcDate(row.cutoffDate),
+        label: row.label,
+      }
+      if (row.id && existingById.has(row.id)) {
+        const existingRow = existingById.get(row.id)!
+        const hasChanges =
+          existingRow.year !== year ||
+          new Date(existingRow.cutoffDate).toISOString().slice(0, 10) !== row.cutoffDate ||
+          (existingRow.label || null) !== (row.label || null)
+        if (hasChanges) {
+          const updatedRow = await tx.fdotCutoff.update({
+            where: { id: row.id },
+            data,
+          })
+          updated += 1
+          persisted.push(updatedRow)
+        } else {
+          persisted.push(existingRow)
+        }
+      } else {
+        const createdRow = await tx.fdotCutoff.create({
+          data: {
+            ...data,
+            createdBy: userId,
+          },
+        })
+        created += 1
+        persisted.push(createdRow)
+      }
+    }
+
+    return persisted
+  })
+
+  const formatted = results
+    .map(toPayload)
+    .sort((a, b) => (a.cutoffDate < b.cutoffDate ? -1 : a.cutoffDate > b.cutoffDate ? 1 : 0))
+
+  const deleted = toDelete.length
+
+  return { created, updated, deleted, records: formatted }
+}
+
+export async function resolveCutoffWindow(
+  year: number,
+  toCutoffIdOrDate: string,
+): Promise<CutoffWindow | null> {
+  const cutoffs = await fetchCutoffsForYear(year)
+  if (!cutoffs.length) return null
+
+  const target = cutoffs.find(c => c.id === toCutoffIdOrDate || c.cutoffDate === toCutoffIdOrDate)
+  if (!target) return null
+
+  const index = cutoffs.findIndex(c => c.id === target.id)
+  let previous: FdotCutoffRecord | null = null
+  if (index > 0) {
+    previous = cutoffs[index - 1]!
+  } else {
+    const priorYear = await fetchCutoffsForYear(year - 1)
+    if (priorYear.length) {
+      previous = priorYear[priorYear.length - 1]!
+    }
+  }
+
+  let startDateUtc: Date
+  if (previous) {
+    startDateUtc = addDays(new Date(previous.cutoffDate + 'T00:00:00Z'), 1)
+  } else {
+    startDateUtc = new Date(Date.UTC(year, 0, 1))
+  }
+  const endDateUtc = new Date(target.cutoffDate + 'T00:00:00Z')
+
+  return {
+    year,
+    startDate: ymd(startDateUtc),
+    endDate: ymd(endDateUtc),
+    startDateUtc,
+    endDateUtc,
+    toCutoff: target,
+    previousCutoff: previous,
+  }
+}
+
+export type AggregatedRow = {
+  jobId: string
+  jobName: string
+  payItem: string
+  description: string
+  unit: string
+  quantity: number
+  firstWorkDate: string
+  lastWorkDate: string
+}
+
+export type AggregatedResult = {
+  rows: AggregatedRow[]
+  totalRows: number
+  page: number
+  pageSize: number
+  jobTotals: Array<{ jobId: string; jobName: string; quantity: number }>
+  grandTotal: number
+}
+
+async function runAggregation(
+  start: Date,
+  endExclusive: Date,
+): Promise<AggregatedRow[]> {
+  const query = Prisma.sql`
+    SELECT
+      j."id" AS job_id,
+      COALESCE(j."name", '') AS job_name,
+      COALESCE(w."pay_item", '') AS pay_item,
+      COALESCE(pi."description", w."pay_item_description", '') AS description,
+      COALESCE(NULLIF(w."unit", ''), pi."unit", '') AS unit,
+      SUM(COALESCE(w."quantity", 0)) AS total_quantity,
+      MIN(w."work_date") AS first_work_date,
+      MAX(w."work_date") AS last_work_date
+    FROM "work_logs" w
+    INNER JOIN "jobs" j ON j."id" = w."job_id"
+    LEFT JOIN "pay_items" pi ON (pi."number" = w."pay_item")
+    WHERE w."work_date" >= ${start} AND w."work_date" < ${endExclusive}
+      AND (
+        COALESCE(j."is_fdot", FALSE) = TRUE OR
+        UPPER(COALESCE(j."client_type", '')) = 'FDOT'
+      )
+    GROUP BY j."id", j."name", w."pay_item", pi."description", pi."unit", w."pay_item_description"
+    ORDER BY j."name" ASC, w."pay_item" ASC
+  `
+
+  try {
+    const rows = await tryPrisma(
+      (p) =>
+        p.$queryRaw<Array<{
+          job_id: string
+          job_name: string | null
+          pay_item: string | null
+          description: string | null
+          unit: string | null
+          total_quantity: Prisma.Decimal | number | null
+          first_work_date: Date | string | null
+          last_work_date: Date | string | null
+        }>>(query),
+      [] as Array<{
+        job_id: string
+        job_name: string | null
+        pay_item: string | null
+        description: string | null
+        unit: string | null
+        total_quantity: Prisma.Decimal | number | null
+        first_work_date: Date | string | null
+        last_work_date: Date | string | null
+      }>,
+    )
+
+    return rows.map(row => ({
+      jobId: String(row.job_id ?? ''),
+      jobName: String(row.job_name ?? ''),
+      payItem: String(row.pay_item ?? ''),
+      description: row.description ? String(row.description) : '',
+      unit: row.unit ? String(row.unit) : '',
+      quantity: Number(row.total_quantity ?? 0),
+      firstWorkDate: row.first_work_date ? new Date(row.first_work_date).toISOString().slice(0, 10) : '',
+      lastWorkDate: row.last_work_date ? new Date(row.last_work_date).toISOString().slice(0, 10) : '',
+    }))
+  } catch (error) {
+    console.error('Failed to aggregate FDOT work logs', error)
+    return []
+  }
+}
+
+export async function generateAggregatedRows(
+  window: CutoffWindow,
+  page: number,
+  pageSize: number,
+): Promise<AggregatedResult> {
+  const safePage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1
+  const safePageSize = Number.isFinite(pageSize) && pageSize > 0 ? Math.min(Math.floor(pageSize), 2000) : 1000
+
+  const endExclusive = addDays(window.endDateUtc, 1)
+  const allRows = await runAggregation(window.startDateUtc, endExclusive)
+  const totalRows = allRows.length
+  const offset = (safePage - 1) * safePageSize
+  const rows = allRows.slice(offset, offset + safePageSize)
+
+  const jobTotalsMap = new Map<string, { jobId: string; jobName: string; quantity: number }>()
+  let grand = 0
+  allRows.forEach(row => {
+    const key = row.jobId || row.jobName
+    const current = jobTotalsMap.get(key) ?? { jobId: row.jobId, jobName: row.jobName, quantity: 0 }
+    current.quantity += row.quantity
+    jobTotalsMap.set(key, current)
+    grand += row.quantity
+  })
+
+  const jobTotals = Array.from(jobTotalsMap.values()).sort((a, b) => a.jobName.localeCompare(b.jobName))
+
+  return {
+    rows,
+    totalRows,
+    page: safePage,
+    pageSize: safePageSize,
+    jobTotals,
+    grandTotal: grand,
+  }
+}
+
+export async function exportAggregatedCsv(window: CutoffWindow): Promise<{ csv: string; rowCount: number }> {
+  const rows = await runAggregation(window.startDateUtc, addDays(window.endDateUtc, 1))
+  const header = '"Job Name","Job ID","Pay Item","Description","Unit","Quantity","First Work Date","Last Work Date"'
+  const lines = rows.map(row => {
+    const cells = [
+      row.jobName,
+      row.jobId,
+      row.payItem,
+      row.description,
+      row.unit,
+      row.quantity.toFixed(2),
+      row.firstWorkDate,
+      row.lastWorkDate,
+    ]
+    return cells
+      .map(value => {
+        const str = value == null ? '' : String(value)
+        return '"' + str.replace(/"/g, '""') + '"'
+      })
+      .join(',')
+  })
+
+  const linesWithWindow = [
+    '"Window Start","Window End"',
+    `"${window.startDate}","${window.endDate}"`,
+    '',
+    header,
+    ...lines,
+  ]
+  return { csv: linesWithWindow.join('\n'), rowCount: rows.length }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Prisma model and migration for fdot_cutoffs records
- expose REST APIs and server helpers to manage cut-off dates and generate FDOT cut-off reports
- build admin and calendar UI for maintaining cut-offs, previewing FDOT aggregates, and exporting CSV reports
- tighten the quantities API to re-filter results on the server for deterministic tests

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e32181e97883208392bfd4b4c49ba7